### PR TITLE
docs(adr): add ADR-003 AGC private cluster preview status gate

### DIFF
--- a/docs/adr/ADR-002-bicep-terraform-parity-contract.md
+++ b/docs/adr/ADR-002-bicep-terraform-parity-contract.md
@@ -1,0 +1,125 @@
+# ADR-002: Bicep + Terraform Parity Contract
+
+**Status:** Accepted  
+**Date:** 2026-04-22  
+**Deciders:** Forge, Lead  
+
+## Context
+
+ADR-001 establishes this repository's wedge: we orchestrate upstream tools and provide ALZ Corp IaC, runbook, and samples. The wedge commits us to dual-stack examples in both Terraform (azurerm + azapi) and Bicep. Our customers split evenly between both languages. Wrapper modules, CI pipelines, and enterprise adoption patterns demand equivalence.
+
+Drift between Bicep and Terraform breaks the wedge. If the Bicep stack outputs AGC identity client IDs under one name and the Terraform stack under another, wrapper modules cannot abstract the choice. If one stack provisions subnets and the other requires pre-existing subnets, migration scripts fail. If outputs are renamed in one stack but not the other, downstream consumers break silently.
+
+This repository has no value if customers must maintain parallel implementations. Parity is the contract. This ADR defines what parity means and how we test it.
+
+## Decision
+
+**We enforce output schema equivalence, not source equivalence.**
+
+### What Parity Means
+
+Parity is defined at the module output boundary. For every Terraform module under `terraform/`, there must exist a Bicep module under `bicep/` with the same logical scope (e.g., `terraform/modules/agc` and `bicep/modules/agc`). Both modules must expose outputs with identical:
+
+1. **Names.** Output keys match exactly (case-sensitive). Example: `agc_frontend_fqdn`, not `agcFrontendFqdn` in one stack and `agc_frontend_fqdn` in the other.
+2. **Value semantics.** Outputs represent the same Azure resources or configuration values. Example: both stacks emit the AGC managed identity's client ID under `agc_identity_client_id`, not one emitting the identity resource ID and the other emitting the client ID.
+3. **Types.** Outputs use equivalent types across both languages. Example: a Terraform `list(string)` must correspond to a Bicep `array` of strings, not a single delimited string.
+
+Source equivalence is NOT required. Bicep and Terraform have different idioms:
+
+- Bicep uses `existing` resources to reference pre-created resources. Terraform uses data sources.
+- Bicep uses symbolic names in modules. Terraform uses resource addresses.
+- Bicep supports inline RBAC assignments on resources. Terraform separates role assignments into separate resources.
+
+Each stack should follow its language's best practices. We test outputs, not source.
+
+### What We Test
+
+Every module directory under `terraform/` and `bicep/` must include an `outputs.schema.json` file that declares the expected output keys, types, and descriptions. Example:
+
+```json
+{
+  "agc_id": {
+    "type": "string",
+    "description": "Azure resource ID of the Application Gateway for Containers"
+  },
+  "agc_frontend_fqdn": {
+    "type": "string",
+    "description": "Fully qualified domain name of the AGC frontend"
+  },
+  "agc_identity_client_id": {
+    "type": "string",
+    "description": "Client ID of the AGC managed identity"
+  },
+  "agc_subnet_id": {
+    "type": "string",
+    "description": "Azure resource ID of the subnet delegated to AGC"
+  }
+}
+```
+
+CI validates:
+
+1. **Schema completeness.** Both Terraform and Bicep modules expose all keys declared in `outputs.schema.json`.
+2. **No drift.** Outputs present in one stack but not declared in `outputs.schema.json` fail validation (prevents undocumented drift).
+3. **Type equivalence.** Terraform `string` maps to Bicep `string`, Terraform `list(string)` maps to Bicep `array`, Terraform `map(string)` maps to Bicep `object`.
+
+We do NOT execute `terraform apply` or `az deployment group create` in CI for parity tests. We rely on `terraform output -json` against a `.tfstate` fixture and `az deployment group what-if --result-format FullResourcePayloads` or pre-validated output manifests. For modules without live deployments, contributors manually validate and document outputs in `outputs.schema.json`.
+
+### The CI Gate
+
+A GitHub Actions workflow `.github/workflows/parity-check.yml` runs on every PR that touches `terraform/`, `bicep/`, or `outputs.schema.json` files. Steps:
+
+1. Discover all `outputs.schema.json` files in the repository.
+2. For each schema file, parse the expected output keys.
+3. For Terraform: run `terraform output -json` against test fixtures or validate the module's `outputs.tf` declares matching keys.
+4. For Bicep: parse the module's `output` declarations and validate keys match.
+5. Fail the build if any key is missing in one stack or undeclared in the schema.
+
+This workflow runs before any manual review. PRs cannot merge without a passing parity check.
+
+## Consequences
+
+### Positive
+
+- **Wrapper modules work.** Customers can choose Terraform or Bicep without changing their orchestration layer. A Terraform wrapper can call our Terraform modules. A Bicep wrapper can call our Bicep modules. Both produce the same outputs.
+- **Predictable migration.** Customers migrating from Bicep to Terraform (or vice versa) can rely on stable output names. No breaking changes in downstream automation.
+- **Documentation clarity.** Runbook steps reference outputs by name. One set of instructions works for both stacks.
+- **Less drift.** CI prevents accidental divergence. Outputs cannot be renamed in one stack without updating both.
+
+### Negative
+
+- **Dual maintenance.** Every contributor must update both stacks. A Terraform-only change requires a Bicep translation. This slows development.
+- **Provider lag.** Some Azure features lag in azurerm or Bicep resource providers. Example: AKS Automatic features often land in azapi before azurerm, and Bicep extensibility providers before native Bicep resources. We must use workarounds (azapi in Terraform, deployment scripts in Bicep) or defer features until both stacks support them.
+- **Test complexity.** We must maintain `outputs.schema.json` files and validate both stacks. This adds cognitive load and CI time.
+
+### Neutral
+
+- **Not every file requires parity.** Terraform-specific tooling (e.g., `terraform fmt`, `tflint` configs) and Bicep-specific tooling (e.g., `bicepconfig.json`) live in their respective directories without equivalents. Only modules with outputs are subject to parity.
+- **Escape hatch exists.** If a feature is only available in one stack, we document the gap in `.squad/decisions.md` with a "deferred parity" decision and a target date for resolution. This unblocks time-sensitive features while preserving the long-term contract.
+
+## Alternatives Considered
+
+### Source-level parity
+
+We could require both stacks to use identical resource blocks, variable names, and structures. Rejected because this is too brittle. Bicep and Terraform have different idioms. Forcing them into the same shape hurts readability and maintainability. We care about outputs, not implementation.
+
+### Single-stack-only with adapter
+
+We could pick one stack (Terraform or Bicep) as the primary and generate the other using a transpiler or adapter layer. Rejected because no reliable bidirectional transpiler exists, and customers need native, idiomatic code in both languages. Generated code is hard to review and maintain.
+
+### Feature-flag drift with deferred decisions
+
+We keep this as an escape hatch. If a feature is only available in azapi or Bicep extensibility providers, we document the gap in `.squad/decisions.md` with a target resolution date. Example: "AGC custom health probes are azapi-only as of 2026-04-22, Bicep parity deferred to 2026-05-15 pending azurerm provider release." This prevents blocking legitimate features while preserving the parity contract as the default.
+
+### No parity enforcement
+
+We could document parity as a goal but not enforce it in CI. Rejected because undocumented drift is worse than no parity at all. Without enforcement, the wedge breaks silently, and customers lose trust.
+
+## References
+
+- [ADR-001: Positioning vs Upstream Tools](./ADR-001-positioning-vs-upstream-tools.md)
+- [Terraform azurerm provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs)
+- [Terraform azapi provider documentation](https://registry.terraform.io/providers/Azure/azapi/latest/docs)
+- [Bicep resource reference for Application Gateway for Containers](https://learn.microsoft.com/en-us/azure/templates/microsoft.servicenetworking/trafficcontrollers)
+- [Bicep extensibility providers](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-extensibility-kubernetes-provider)
+- [Issue #7: Define parity test and CI gate](https://github.com/martinopedal/aks-automatic-ingress-migration/issues/7)

--- a/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
+++ b/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
@@ -1,0 +1,99 @@
+# ADR-003: AGC Private Cluster Preview Status Gate
+
+**Status:** Accepted  
+**Date:** 2026-04-22  
+**Deciders:** Sage, Sentinel  
+
+## Context
+
+ADR-001 established ALZ Corp as the default positioning for this repository. ALZ Corp means hub-spoke networks with central Azure Firewall egress, no public IPs on AKS nodes, and private cluster API servers. This is the Microsoft-recommended architecture for enterprise AKS deployments, per [Azure Landing Zone guidance](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator).
+
+Application Gateway for Containers (AGC) reached General Availability (GA) for public AKS clusters in November 2025, including Web Application Firewall (WAF) support. However, as of April 22, 2026, AGC support for private AKS clusters is still in preview with no official GA date published by Microsoft.
+
+This creates a hard prerequisite gap. Our default scenario (private cluster) requires a preview feature. Production-supported deployments typically cannot rely on preview features. While customers can use AGC with private clusters today, Microsoft does not guarantee backward-compatibility, SLA, or long-term support for preview functionality.
+
+Research from Azure engineering blogs and migration guides published in early 2026 suggests GA for private cluster support is expected mid-2026, but this is not officially confirmed by Microsoft documentation. The [Azure Updates page](https://azure.microsoft.com/en-us/updates/) does not list a specific GA timeline as of this date. The [AGC overview page](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/overview) accessed April 22, 2026, confirms AGC is GA and lists 23 supported regions but does not distinguish public versus private cluster support status.
+
+Additional considerations:
+- Kubenet networking is not supported by AGC. Only Azure CNI (static or dynamic IP) is compatible.
+- Some regions may support AGC generally but have different timelines or limitations for private cluster scenarios.
+- Preview features require explicit Azure subscription preview registration in some cases.
+
+The November 2026 deadline for ingress-nginx retirement means customers need clarity now, even if the full AGC private cluster GA occurs mid-2026.
+
+## Decision
+
+We treat AGC-on-private-cluster as a **hard prerequisite block** that must be surfaced at the start of the runbook, before any infrastructure provisioning or translation steps. The runbook will not assume customers can proceed with private clusters unless they explicitly accept preview risk or wait for GA.
+
+Concrete deliverables:
+
+1. **Runbook prerequisite check:** Create `docs/runbook/00-prereq-agc-availability.md` as the first step in the runbook. This document will:
+   - State that AGC private cluster support is in preview as of the last verified date.
+   - Define what "preview" means (no SLA, potential breaking changes, not recommended for production without Azure support engagement).
+   - Provide a clear decision tree: if you have a private cluster and cannot accept preview risk, stop here.
+   - Document the workaround path: customers can opt for a public cluster (not ALZ Corp default), use a hybrid approach (public frontend, private backend), or engage Azure support for preview registration and guidance.
+   - Link to the per-region matrix for availability nuances.
+
+2. **Per-region availability matrix:** Create `docs/agc-region-matrix.md` with:
+   - A table listing the 23 AGC-supported regions (as of April 22, 2026: Australia East, Brazil South, Canada Central, Central India, Central US, East Asia, East US, East US 2, France Central, Germany West Central, Korea Central, North Central US, North Europe, Norway East, South Central US, Southeast Asia, Switzerland North, UAE North, UK South, West US, West US 2, West US 3, West Europe).
+   - A column noting private cluster support status per region (initially marked "Preview, no GA date" for all).
+   - A "Last Verified" date at the top of the file.
+   - A note that this matrix is reviewed quarterly by Sage and updated when Microsoft publishes GA announcements.
+
+3. **Quarterly review cadence:** Sage owns a recurring task to check the [Azure Updates page](https://azure.microsoft.com/en-us/updates/) and AGC documentation quarterly. If GA is announced, `docs/runbook/00-prereq-agc-availability.md` and `docs/agc-region-matrix.md` are updated, and the runbook prerequisite check is relaxed or removed.
+
+4. **Escalation path:** The prerequisite document includes links to:
+   - [Azure support request process](https://learn.microsoft.com/en-us/azure/azure-portal/supportability/how-to-create-azure-support-request)
+   - [Azure preview feature registration guidance](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/preview-features)
+   - The AKS feedback forum at [feedback.azure.com](https://feedback.azure.com/d365community/forum/8ae9bf04-8326-ec11-b6e6-000d3a4f0789?&c=69637543-1829-ee11-bdf4-000d3a1ab360)
+
+This ADR does not mandate creating the full content of `docs/runbook/00-prereq-agc-availability.md` or `docs/agc-region-matrix.md` immediately. It defines the structure and commits to producing them. Those files will be delivered under separate tracked issues.
+
+## Consequences
+
+### Positive
+
+- **Transparency.** Customers understand the preview risk before investing time in migration.
+- **Avoids silent production failures.** Surfacing the limitation early prevents customers from discovering it after infrastructure is deployed.
+- **Clear workaround path.** Customers can make informed decisions: wait for GA, accept preview risk with Azure support, or adjust architecture (public cluster, hybrid model).
+- **Maintains ALZ Corp wedge integrity.** We do not hide the default scenario's limitations. ADR-001 said private clusters are the default. This ADR says that default has a preview dependency and we document it honestly.
+
+### Negative
+
+- **Slows time-to-first-success.** Some customers will hit the prerequisite check and stop, delaying their migration.
+- **Maintenance burden.** Sage must review the matrix quarterly and monitor Azure Updates. This is recurring effort.
+- **Complexity for edge cases.** Customers in regions where AGC is not supported at all (outside the 23 listed) need separate guidance. The matrix must account for "not supported" versus "preview" versus "GA."
+
+### Neutral
+
+- **Creates a forcing function for GA.** If Microsoft sees customers blocked by the prerequisite check, it may accelerate private cluster GA. Conversely, if preview is working well, customers may accept the risk. Either outcome is information.
+
+## Alternatives Considered
+
+### Hide the limitation behind a warning
+
+We could include a small warning in the runbook ("private cluster support is in preview") but let customers proceed without a hard stop. Rejected because customers will encounter production issues, open support tickets, and blame the runbook for not being explicit. A hard gate is clearer.
+
+### Only support public clusters
+
+We could abandon ADR-001's ALZ Corp wedge and only document public cluster migrations. Rejected because it contradicts the enterprise positioning. ALZ Corp customers are the primary audience for this runbook. Ignoring their architecture is a non-starter.
+
+### Wait for GA before launching the runbook
+
+We could delay all runbook publication until AGC private cluster support is GA. Rejected because the November 2026 ingress-nginx deadline does not permit waiting. Customers need migration guidance now. If GA occurs mid-2026, we have months to refine the runbook post-GA.
+
+### Treat preview as "good enough" and document without a gate
+
+We could document the preview status but not call it a hard prerequisite block. Rejected because "preview" means no SLA, potential breaking changes, and lack of production support guarantees. Enterprises in ALZ Corp environments cannot risk that without explicit acceptance.
+
+## References
+
+- [Application Gateway for Containers overview](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/overview) (accessed 2026-04-22)
+- [Azure Updates](https://azure.microsoft.com/en-us/updates/) (accessed 2026-04-22)
+- [AKS App Routing addon retirement timeline](https://learn.microsoft.com/en-us/azure/aks/http-application-routing-migrate) (accessed 2026-04-22)
+- [Azure Landing Zone guidance for AKS](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator) (accessed 2026-04-22)
+- [Azure support request process](https://learn.microsoft.com/en-us/azure/azure-portal/supportability/how-to-create-azure-support-request)
+- [Azure preview feature registration](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/preview-features)
+- ADR-001: Positioning vs Upstream Tools (private cluster as ALZ Corp default)
+- Issue #8: AGC private cluster preview status gate
+- Web search results: AGC private cluster GA expected mid-2026 per engineering blogs, not yet officially confirmed by Microsoft (searched 2026-04-22)


### PR DESCRIPTION
Closes #8

## Summary

Establishes AGC private cluster support as a hard prerequisite block in the runbook.

## Key Points

- AGC is GA for public clusters (Nov 2025), but private cluster support is still in preview as of April 2026
- No official GA date published by Microsoft, though engineering blogs suggest mid-2026
- ADR-001 committed us to ALZ Corp default (private cluster), so we must surface this limitation explicitly

## Deliverables Defined

1. **Runbook prerequisite check:** docs/runbook/00-prereq-agc-availability.md (structure defined, content in separate issue)
2. **Per-region matrix:** docs/agc-region-matrix.md with 23 supported regions and preview status tracking
3. **Quarterly review:** Sage owns checking Azure Updates and MS docs for GA announcements
4. **Escalation path:** Links to Azure support, preview registration, and feedback forum

## Validation

- Verified AGC overview page (April 22, 2026): lists 23 regions, no private/public distinction
- Searched Azure Updates: no published GA date for private cluster support
- Web search: engineering blogs suggest mid-2026 GA, not officially confirmed

## Related

- ADR-001: Positioning vs Upstream Tools (ALZ Corp wedge)
- Issue #8: Surface AGC private cluster preview status