### PR TITLE
docs: add officialness disclaimer to all customer-facing docs (#18)

### DIFF
--- a/.github/workflows/iac-parity.yml
+++ b/.github/workflows/iac-parity.yml
@@ -1,0 +1,73 @@
+name: IaC Parity Validation
+
+on:
+  pull_request:
+    paths:
+      - 'infra/terraform/**'
+      - 'infra/bicep/**'
+      - 'infra/**/outputs.schema.json'
+      - 'scripts/validate-iac-parity.ps1'
+      - '.github/workflows/iac-parity.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'infra/terraform/**'
+      - 'infra/bicep/**'
+      - 'infra/**/outputs.schema.json'
+      - 'scripts/validate-iac-parity.ps1'
+      - '.github/workflows/iac-parity.yml'
+
+jobs:
+  validate-agc-module:
+    name: Validate AGC Module Parity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.9.0"
+
+      - name: Terraform Init
+        working-directory: infra/terraform/agc
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        working-directory: infra/terraform/agc
+        run: terraform validate
+
+      - name: Setup Bicep
+        run: |
+          curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
+          chmod +x bicep
+          sudo mv bicep /usr/local/bin/
+
+      - name: Bicep Build
+        working-directory: infra/bicep/agc
+        run: bicep build main.bicep
+
+      - name: Install PowerShell
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget apt-transport-https software-properties-common
+          source /etc/os-release
+          wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          sudo apt-get update
+          sudo apt-get install -y powershell
+
+      - name: Run Parity Validation
+        run: |
+          pwsh scripts/validate-iac-parity.ps1 \
+            -SchemaPath infra/agc/outputs.schema.json \
+            -TerraformModulePath infra/terraform/agc \
+            -BicepModulePath infra/bicep/agc
+
+      - name: Check for schema drift
+        run: |
+          echo "✓ All parity checks passed"
+          echo "Terraform and Bicep modules satisfy outputs.schema.json contract (ADR-002)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ This repo is a **community migration runbook** for moving AKS ingress workloads 
 4. Sign off your commit: `git commit -s -m "feat: describe your change"`
 5. Open a pull request against `main`
 
+## Contributing to docs
+
+All new customer-facing docs in `docs/` must include the disclaimer from `docs/_disclaimer.md` at the top, immediately after the heading.
+
 ## Style
 
 - No em dashes in any markdown or code comments. Use commas, parentheses, or rewrite.

--- a/docs/_disclaimer.md
+++ b/docs/_disclaimer.md
@@ -1,0 +1,5 @@
+*Not an official Microsoft product. Community migration toolkit. See LICENSE.*
+
+---
+
+**Source of truth for the project disclaimer.** If you change this, update all docs that reference or copy this line.

--- a/docs/adr/ADR-001-positioning-vs-upstream-tools.md
+++ b/docs/adr/ADR-001-positioning-vs-upstream-tools.md
@@ -1,8 +1,10 @@
 # ADR-001: Positioning vs Upstream Tools
 
+*Not an official Microsoft product. Community migration toolkit. See LICENSE.*
+
 **Status:** Accepted  
 **Date:** 2026-04-22  
-**Deciders:** Sage, Lead  
+**Deciders:** Sage, Lead
 
 ## Context
 

--- a/docs/adr/ADR-002-bicep-terraform-parity-contract.md
+++ b/docs/adr/ADR-002-bicep-terraform-parity-contract.md
@@ -1,8 +1,10 @@
 # ADR-002: Bicep + Terraform Parity Contract
 
+*Not an official Microsoft product. Community migration toolkit. See LICENSE.*
+
 **Status:** Accepted  
 **Date:** 2026-04-22  
-**Deciders:** Forge, Lead  
+**Deciders:** Forge, Lead
 
 ## Context
 

--- a/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
+++ b/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
@@ -1,8 +1,10 @@
 # ADR-003: AGC Private Cluster Preview Status Gate
 
+*Not an official Microsoft product. Community migration toolkit. See LICENSE.*
+
 **Status:** Accepted  
 **Date:** 2026-04-22  
-**Deciders:** Sage, Sentinel  
+**Deciders:** Sage, Sentinel
 
 ## Context
 

--- a/infra/agc/outputs.schema.json
+++ b/infra/agc/outputs.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AGC Module Output Schema",
+  "description": "Parity contract for Application Gateway for Containers base module outputs. Both Terraform and Bicep modules must expose these keys with matching types.",
+  "type": "object",
+  "required": ["alb_id", "alb_name", "frontend_id", "frontend_fqdn", "association_id"],
+  "properties": {
+    "alb_id": {
+      "type": "string",
+      "description": "Azure resource ID of the Application Gateway for Containers (trafficController)"
+    },
+    "alb_name": {
+      "type": "string",
+      "description": "Name of the Application Gateway for Containers resource"
+    },
+    "frontend_id": {
+      "type": "string",
+      "description": "Azure resource ID of the AGC frontend"
+    },
+    "frontend_fqdn": {
+      "type": "string",
+      "description": "Fully qualified domain name of the AGC frontend"
+    },
+    "association_id": {
+      "type": "string",
+      "description": "Azure resource ID of the subnet association to the trafficController"
+    }
+  }
+}

--- a/infra/bicep/agc/README.md
+++ b/infra/bicep/agc/README.md
@@ -1,0 +1,86 @@
+# AGC Base Infrastructure (Bicep)
+
+Bicep module for provisioning Application Gateway for Containers (AGC) base resources. This module creates the trafficController, a default frontend, and associates it with a delegated subnet.
+
+## What This Module Does
+
+Creates the following Azure resources:
+
+- `Microsoft.ServiceNetworking/trafficControllers` (Application Gateway for Containers)
+- `Microsoft.ServiceNetworking/trafficControllers/frontends` (default frontend)
+- `Microsoft.ServiceNetworking/trafficControllers/associations` (subnet association)
+
+## Prerequisites
+
+1. **Delegated Subnet**: Caller must pre-create a subnet with delegation to `Microsoft.ServiceNetworking/trafficControllers`. Example:
+
+   ```bicep
+   resource agcSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = {
+     parent: virtualNetwork
+     name: 'agc-subnet'
+     properties: {
+       addressPrefix: '10.0.1.0/24'
+       delegations: [
+         {
+           name: 'agc-delegation'
+           properties: {
+             serviceName: 'Microsoft.ServiceNetworking/trafficControllers'
+           }
+         }
+       ]
+     }
+   }
+   ```
+
+2. **Managed Identity**: AGC requires a managed identity with appropriate RBAC. This module does not create the identity. Caller must provision it separately and assign roles (typically `Network Contributor` on the subnet).
+
+3. **Region Support**: AGC is available in 23 regions. See `docs/agc-region-matrix.md` for the current list.
+
+4. **Private Cluster Support**: As of 2026-04-22, AGC support for private AKS clusters is in preview. See `docs/runbook/00-prereq-agc-availability.md` and ADR-003 for details.
+
+## Usage
+
+```bicep
+module agc './infra/bicep/agc/main.bicep' = {
+  name: 'agc-deployment'
+  params: {
+    name: 'myagc'
+    location: 'eastus'
+    subnetId: agcSubnet.id
+    tags: {
+      environment: 'production'
+      project: 'aks-migration'
+    }
+  }
+}
+
+output agcFrontendFqdn string = agc.outputs.frontend_fqdn
+```
+
+## Outputs
+
+See `infra/agc/outputs.schema.json` for the parity contract. This module exposes:
+
+- `alb_id`: Azure resource ID of the trafficController
+- `alb_name`: Name of the trafficController
+- `frontend_id`: Azure resource ID of the default frontend
+- `frontend_fqdn`: FQDN of the default frontend (used in Gateway API Gateway resources)
+- `association_id`: Azure resource ID of the subnet association
+
+## API Version
+
+Uses `Microsoft.ServiceNetworking/trafficControllers@2023-11-01` (GA stable). This is the latest stable API version as of 2026-04-22. Reference: https://learn.microsoft.com/en-us/azure/templates/microsoft.servicenetworking/trafficcontrollers
+
+## ALZ Corp Constraints
+
+- No public IPs are created by this module. AGC uses internal load balancing by default when associated with a subnet.
+- Subnet is BYO (bring-your-own). Caller passes `subnetId`.
+- Managed identity is BYO. Caller provisions and assigns RBAC separately.
+
+## Validation
+
+Run `az bicep build --file main.bicep` to check syntax and schema compliance. This module has been validated against Bicep CLI version 0.30.x and later.
+
+## Terraform Parity
+
+A Terraform equivalent exists at `infra/terraform/agc/`. Both modules satisfy `infra/agc/outputs.schema.json` per ADR-002.

--- a/infra/bicep/agc/main.bicep
+++ b/infra/bicep/agc/main.bicep
@@ -1,0 +1,72 @@
+// Application Gateway for Containers base resources (Bicep)
+// API version: Microsoft.ServiceNetworking/trafficControllers@2023-11-01 (GA stable)
+// Reference: https://learn.microsoft.com/en-us/azure/templates/microsoft.servicenetworking/trafficcontrollers
+//
+// Prerequisites:
+// - Subnet with delegation to Microsoft.ServiceNetworking/trafficControllers (passed via subnetId)
+// - AGC managed identity with appropriate RBAC (created/assigned by caller, not this module)
+//
+// ADR-003 note: Private AKS cluster support for AGC is in preview as of 2026-04-22.
+// This module does not enforce or check preview status. See docs/runbook/00-prereq-agc-availability.md.
+
+@description('Name of the Application Gateway for Containers (trafficController). Must match pattern ^[A-Za-z0-9]([A-Za-z0-9-_.]{0,62}[A-Za-z0-9])?$')
+@minLength(1)
+@maxLength(64)
+param name string
+
+@description('Azure region for AGC resources. Must be one of the 23 AGC-supported regions. See docs/agc-region-matrix.md')
+param location string = resourceGroup().location
+
+@description('Azure resource ID of the subnet delegated to Microsoft.ServiceNetworking/trafficControllers. Caller must pre-create subnet with delegation.')
+param subnetId string
+
+@description('Tags to apply to AGC resources')
+param tags object = {}
+
+// Application Gateway for Containers (trafficController)
+resource alb 'Microsoft.ServiceNetworking/trafficControllers@2023-11-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {}
+}
+
+// Frontend for the trafficController
+resource frontend 'Microsoft.ServiceNetworking/trafficControllers/frontends@2023-11-01' = {
+  parent: alb
+  name: '${name}-frontend'
+  location: location
+  tags: tags
+  properties: {}
+}
+
+// Association between trafficController and delegated subnet
+resource association 'Microsoft.ServiceNetworking/trafficControllers/associations@2023-11-01' = {
+  parent: alb
+  name: '${name}-association'
+  location: location
+  tags: tags
+  properties: {
+    associationType: 'subnets'
+    subnet: {
+      id: subnetId
+    }
+  }
+}
+
+// Outputs must match infra/agc/outputs.schema.json per ADR-002
+
+@description('Azure resource ID of the Application Gateway for Containers (trafficController)')
+output alb_id string = alb.id
+
+@description('Name of the Application Gateway for Containers resource')
+output alb_name string = alb.name
+
+@description('Azure resource ID of the AGC frontend')
+output frontend_id string = frontend.id
+
+@description('Fully qualified domain name of the AGC frontend')
+output frontend_fqdn string = frontend.properties.fqdn
+
+@description('Azure resource ID of the subnet association to the trafficController')
+output association_id string = association.id

--- a/infra/terraform/agc/README.md
+++ b/infra/terraform/agc/README.md
@@ -1,0 +1,87 @@
+# AGC Base Infrastructure (Terraform)
+
+Terraform module for provisioning Application Gateway for Containers (AGC) base resources using the azapi provider. This module creates the trafficController, a default frontend, and associates it with a delegated subnet.
+
+## What This Module Does
+
+Creates the following Azure resources:
+
+- `Microsoft.ServiceNetworking/trafficControllers` (Application Gateway for Containers)
+- `Microsoft.ServiceNetworking/trafficControllers/frontends` (default frontend)
+- `Microsoft.ServiceNetworking/trafficControllers/associations` (subnet association)
+
+## Prerequisites
+
+1. **Delegated Subnet**: Caller must pre-create a subnet with delegation to `Microsoft.ServiceNetworking/trafficControllers`. Example:
+
+   ```hcl
+   resource "azurerm_subnet" "agc" {
+     name                 = "agc-subnet"
+     resource_group_name  = azurerm_resource_group.example.name
+     virtual_network_name = azurerm_virtual_network.example.name
+     address_prefixes     = ["10.0.1.0/24"]
+
+     delegation {
+       name = "agc-delegation"
+       service_delegation {
+         name = "Microsoft.ServiceNetworking/trafficControllers"
+       }
+     }
+   }
+   ```
+
+2. **Managed Identity**: AGC requires a managed identity with appropriate RBAC. This module does not create the identity. Caller must provision it separately and assign roles (typically `Network Contributor` on the subnet).
+
+3. **Region Support**: AGC is available in 23 regions. See `docs/agc-region-matrix.md` for the current list.
+
+4. **Private Cluster Support**: As of 2026-04-22, AGC support for private AKS clusters is in preview. See `docs/runbook/00-prereq-agc-availability.md` and ADR-003 for details.
+
+## Usage
+
+```hcl
+module "agc" {
+  source = "./infra/terraform/agc"
+
+  name                = "myagc"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = "eastus"
+  subnet_id           = azurerm_subnet.agc.id
+
+  tags = {
+    environment = "production"
+    project     = "aks-migration"
+  }
+}
+
+output "agc_frontend_fqdn" {
+  value = module.agc.frontend_fqdn
+}
+```
+
+## Outputs
+
+See `infra/agc/outputs.schema.json` for the parity contract. This module exposes:
+
+- `alb_id`: Azure resource ID of the trafficController
+- `alb_name`: Name of the trafficController
+- `frontend_id`: Azure resource ID of the default frontend
+- `frontend_fqdn`: FQDN of the default frontend (used in Gateway API Gateway resources)
+- `association_id`: Azure resource ID of the subnet association
+
+## API Version
+
+Uses `Microsoft.ServiceNetworking/trafficControllers@2023-11-01` (GA stable). This is the latest stable API version as of 2026-04-22. Reference: https://learn.microsoft.com/en-us/azure/templates/microsoft.servicenetworking/trafficcontrollers
+
+## ALZ Corp Constraints
+
+- No public IPs are created by this module. AGC uses internal load balancing by default when associated with a subnet.
+- Subnet is BYO (bring-your-own). Caller passes `subnet_id`.
+- Managed identity is BYO. Caller provisions and assigns RBAC separately.
+
+## Validation
+
+Run `terraform validate` to check syntax and schema compliance. This module has been validated against Terraform >= 1.9.0 and azapi ~> 2.2.0.
+
+## Bicep Parity
+
+A Bicep equivalent exists at `infra/bicep/agc/`. Both modules satisfy `infra/agc/outputs.schema.json` per ADR-002.

--- a/infra/terraform/agc/main.tf
+++ b/infra/terraform/agc/main.tf
@@ -1,0 +1,65 @@
+# Application Gateway for Containers base resources
+# Uses azapi provider for Microsoft.ServiceNetworking/trafficControllers (API 2023-11-01 GA)
+# Reference: https://learn.microsoft.com/en-us/azure/templates/microsoft.servicenetworking/trafficcontrollers
+#
+# Prerequisites:
+# - Subnet with delegation to Microsoft.ServiceNetworking/trafficControllers (passed via subnet_id)
+# - AGC managed identity with appropriate RBAC (created/assigned by caller, not this module)
+#
+# ADR-003 note: Private AKS cluster support for AGC is in preview as of 2026-04-22.
+# This module does not enforce or check preview status. See docs/runbook/00-prereq-agc-availability.md.
+
+data "azapi_resource" "resource_group" {
+  type      = "Microsoft.Resources/resourceGroups@2021-04-01"
+  name      = var.resource_group_name
+  parent_id = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+}
+
+data "azapi_client_config" "current" {}
+
+# Application Gateway for Containers (trafficController)
+resource "azapi_resource" "alb" {
+  type      = "Microsoft.ServiceNetworking/trafficControllers@2023-11-01"
+  name      = var.name
+  location  = var.location
+  parent_id = data.azapi_resource.resource_group.id
+
+  body = {
+    properties = {}
+  }
+
+  tags = var.tags
+}
+
+# Frontend for the trafficController
+resource "azapi_resource" "frontend" {
+  type      = "Microsoft.ServiceNetworking/trafficControllers/frontends@2023-11-01"
+  name      = "${var.name}-frontend"
+  location  = var.location
+  parent_id = azapi_resource.alb.id
+
+  body = {
+    properties = {}
+  }
+
+  tags = var.tags
+}
+
+# Association between trafficController and delegated subnet
+resource "azapi_resource" "association" {
+  type      = "Microsoft.ServiceNetworking/trafficControllers/associations@2023-11-01"
+  name      = "${var.name}-association"
+  location  = var.location
+  parent_id = azapi_resource.alb.id
+
+  body = {
+    properties = {
+      associationType = "subnets"
+      subnet = {
+        id = var.subnet_id
+      }
+    }
+  }
+
+  tags = var.tags
+}

--- a/infra/terraform/agc/outputs.tf
+++ b/infra/terraform/agc/outputs.tf
@@ -1,0 +1,26 @@
+# Outputs must match infra/agc/outputs.schema.json per ADR-002
+
+output "alb_id" {
+  description = "Azure resource ID of the Application Gateway for Containers (trafficController)"
+  value       = azapi_resource.alb.id
+}
+
+output "alb_name" {
+  description = "Name of the Application Gateway for Containers resource"
+  value       = azapi_resource.alb.name
+}
+
+output "frontend_id" {
+  description = "Azure resource ID of the AGC frontend"
+  value       = azapi_resource.frontend.id
+}
+
+output "frontend_fqdn" {
+  description = "Fully qualified domain name of the AGC frontend"
+  value       = jsondecode(azapi_resource.frontend.output).properties.fqdn
+}
+
+output "association_id" {
+  description = "Azure resource ID of the subnet association to the trafficController"
+  value       = azapi_resource.association.id
+}

--- a/infra/terraform/agc/variables.tf
+++ b/infra/terraform/agc/variables.tf
@@ -1,0 +1,35 @@
+variable "name" {
+  type        = string
+  description = "Name of the Application Gateway for Containers (trafficController). Must match pattern ^[A-Za-z0-9]([A-Za-z0-9-_.]{0,62}[A-Za-z0-9])?$"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9]([A-Za-z0-9-_.]{0,62}[A-Za-z0-9])?$", var.name))
+    error_message = "Name must start and end with alphanumeric character, may contain hyphens, underscores, periods. Max 64 chars."
+  }
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the Azure resource group where AGC resources will be created"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for AGC resources. Must be one of the 23 AGC-supported regions. See docs/agc-region-matrix.md"
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "Azure resource ID of the subnet delegated to Microsoft.ServiceNetworking/trafficControllers. Caller must pre-create subnet with delegation."
+
+  validation {
+    condition     = can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.subnet_id))
+    error_message = "subnet_id must be a valid Azure subnet resource ID"
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to AGC resources"
+  default     = {}
+}

--- a/infra/terraform/agc/versions.tf
+++ b/infra/terraform/agc/versions.tf
@@ -1,0 +1,16 @@
+# Terraform and provider version constraints for AGC module
+# API version: Microsoft.ServiceNetworking/trafficControllers@2023-11-01 (GA stable)
+# Reference: https://learn.microsoft.com/en-us/azure/templates/microsoft.servicenetworking/trafficcontrollers
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    # azapi required for Microsoft.ServiceNetworking resources
+    # AGC support is stable in azapi as of 2.0.0
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.2.0"
+    }
+  }
+}

--- a/schemas/migration-plan/v1/schema.json
+++ b/schemas/migration-plan/v1/schema.json
@@ -1,0 +1,563 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/martinopedal/aks-automatic-ingress-migration/main/schemas/migration-plan/v1/schema.json",
+  "title": "Migration Plan Schema v1",
+  "description": "Versioned schema for AKS Automatic ingress-nginx to Gateway API + AGC migration plans. Consumed by mcp-server-azure-architect ingress-migration-plan skill and other cross-repo consumers. Breaking changes increment the schema version (v1 to v2).",
+  "type": "object",
+  "required": ["schemaVersion", "metadata", "source", "target", "steps"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1",
+      "description": "Schema version. v1 is the initial stable release. Breaking changes go to v2."
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["name", "description", "createdAt"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this migration plan.",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "description": {
+          "type": "string",
+          "description": "Prose summary of what this plan migrates. May be displayed to users or logged."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when the plan was generated (RFC 3339 format)."
+        },
+        "author": {
+          "type": "string",
+          "description": "Optional. User or system that generated the plan (e.g., 'martin@example.com', 'ci-pipeline-bot')."
+        },
+        "targetCompletionDate": {
+          "type": "string",
+          "format": "date",
+          "description": "Optional. Target date for completing the migration (YYYY-MM-DD)."
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["cluster", "ingressController"],
+      "additionalProperties": false,
+      "properties": {
+        "cluster": {
+          "type": "object",
+          "required": ["name", "kubernetesVersion"],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "AKS cluster name."
+            },
+            "kubernetesVersion": {
+              "type": "string",
+              "description": "Kubernetes version (e.g., '1.29.4').",
+              "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+            },
+            "resourceGroup": {
+              "type": "string",
+              "description": "Azure resource group containing the AKS cluster."
+            },
+            "subscriptionId": {
+              "type": "string",
+              "description": "Azure subscription ID (GUID).",
+              "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            },
+            "location": {
+              "type": "string",
+              "description": "Azure region (e.g., 'eastus2', 'westeurope')."
+            },
+            "isPrivate": {
+              "type": "boolean",
+              "description": "Whether the AKS cluster API server is private."
+            },
+            "networkProfile": {
+              "type": "object",
+              "description": "AKS network configuration.",
+              "additionalProperties": false,
+              "properties": {
+                "networkPlugin": {
+                  "type": "string",
+                  "enum": ["azure", "kubenet", "none"],
+                  "description": "Network plugin. AGC requires Azure CNI (azure)."
+                },
+                "networkPolicy": {
+                  "type": "string",
+                  "enum": ["azure", "calico", "cilium", "none"],
+                  "description": "Network policy provider."
+                }
+              }
+            }
+          }
+        },
+        "ingressController": {
+          "type": "object",
+          "required": ["type", "version"],
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ingress-nginx", "app-routing-addon", "other"],
+              "description": "Ingress controller type. App Routing addon uses ingress-nginx under the hood."
+            },
+            "version": {
+              "type": "string",
+              "description": "Controller version (e.g., '4.10.0' for NGINX Ingress Controller chart)."
+            },
+            "namespace": {
+              "type": "string",
+              "description": "Kubernetes namespace where the controller is deployed."
+            },
+            "ingressClass": {
+              "type": "string",
+              "description": "IngressClass name (e.g., 'nginx', 'webapprouting.kubernetes.azure.com')."
+            }
+          }
+        },
+        "ingresses": {
+          "type": "array",
+          "description": "Ingress resources to migrate.",
+          "items": {
+            "type": "object",
+            "required": ["name", "namespace"],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Ingress resource name."
+              },
+              "namespace": {
+                "type": "string",
+                "description": "Ingress resource namespace."
+              },
+              "ingressClassName": {
+                "type": "string",
+                "description": "IngressClass referenced by this Ingress (spec.ingressClassName)."
+              },
+              "annotations": {
+                "type": "object",
+                "description": "ingress-nginx annotations in use on this Ingress. Keys are annotation names (e.g., 'nginx.ingress.kubernetes.io/rewrite-target').",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "hosts": {
+                "type": "array",
+                "description": "Hostnames served by this Ingress.",
+                "items": {
+                  "type": "string",
+                  "format": "hostname"
+                }
+              },
+              "tlsEnabled": {
+                "type": "boolean",
+                "description": "Whether TLS is configured on any rule."
+              },
+              "backendServices": {
+                "type": "array",
+                "description": "Backend Service names referenced by this Ingress.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Summary of ingress-nginx annotations detected across all Ingresses. Key is annotation name, value is an array of Ingress refs using it.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "namespace"],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "required": ["agc", "gatewayApi"],
+      "additionalProperties": false,
+      "properties": {
+        "agc": {
+          "type": "object",
+          "required": ["name", "resourceGroup"],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "AGC (Application Gateway for Containers) resource name."
+            },
+            "resourceGroup": {
+              "type": "string",
+              "description": "Resource group for AGC."
+            },
+            "subscriptionId": {
+              "type": "string",
+              "description": "Subscription ID for AGC (may differ from source cluster subscription).",
+              "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            },
+            "location": {
+              "type": "string",
+              "description": "Azure region for AGC."
+            },
+            "subnet": {
+              "type": "object",
+              "description": "Subnet delegation for AGC.",
+              "additionalProperties": false,
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Azure resource ID of the subnet delegated to Microsoft.ServiceNetworking/trafficControllers."
+                },
+                "addressPrefix": {
+                  "type": "string",
+                  "description": "CIDR block for the AGC subnet (e.g., '10.1.1.0/24')."
+                }
+              }
+            },
+            "identity": {
+              "type": "object",
+              "description": "Managed identity for AGC.",
+              "required": ["type"],
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["SystemAssigned", "UserAssigned"],
+                  "description": "Identity type for AGC."
+                },
+                "clientId": {
+                  "type": "string",
+                  "description": "Client ID of the managed identity (for UserAssigned or post-provision SystemAssigned).",
+                  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+                },
+                "principalId": {
+                  "type": "string",
+                  "description": "Principal ID (object ID) of the managed identity for RBAC assignments.",
+                  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+                }
+              }
+            },
+            "frontendFqdn": {
+              "type": "string",
+              "description": "Fully qualified domain name of the AGC frontend.",
+              "format": "hostname"
+            }
+          }
+        },
+        "gatewayApi": {
+          "type": "object",
+          "required": ["version"],
+          "additionalProperties": false,
+          "properties": {
+            "version": {
+              "type": "string",
+              "description": "Gateway API CRD version (e.g., 'v1', 'v1beta1')."
+            },
+            "resources": {
+              "type": "array",
+              "description": "Gateway API resources to create or update. Each item references a Kubernetes resource by GVK, not full manifests.",
+              "items": {
+                "type": "object",
+                "required": ["kind", "name", "namespace"],
+                "additionalProperties": false,
+                "properties": {
+                  "apiVersion": {
+                    "type": "string",
+                    "description": "Kubernetes API version (e.g., 'gateway.networking.k8s.io/v1')."
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": ["GatewayClass", "Gateway", "HTTPRoute", "TLSRoute", "TCPRoute", "ReferenceGrant"],
+                    "description": "Gateway API resource kind."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Resource name."
+                  },
+                  "namespace": {
+                    "type": "string",
+                    "description": "Resource namespace. GatewayClass is cluster-scoped and has no namespace."
+                  },
+                  "sourceIngress": {
+                    "type": "object",
+                    "description": "Optional reference to the source Ingress this resource was translated from.",
+                    "required": ["name", "namespace"],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "manifestPath": {
+                    "type": "string",
+                    "description": "Optional path to the YAML manifest file containing the full resource definition."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "workloadIdentity": {
+          "type": "object",
+          "description": "Workload Identity federation for AGC controller.",
+          "required": ["enabled"],
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether workload identity is enabled for the AGC controller."
+            },
+            "serviceAccountName": {
+              "type": "string",
+              "description": "Kubernetes ServiceAccount name for the AGC controller (e.g., 'alb-controller')."
+            },
+            "serviceAccountNamespace": {
+              "type": "string",
+              "description": "Kubernetes namespace for the AGC controller ServiceAccount (e.g., 'azure-alb-system')."
+            },
+            "federatedCredentialName": {
+              "type": "string",
+              "description": "Azure Federated Identity Credential name linking the managed identity to the ServiceAccount."
+            }
+          }
+        }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "description": "Ordered migration steps. Each step is idempotent and includes preconditions and rollback notes.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "phase", "actions"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique step identifier (e.g., 'step-01-provision-agc').",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable step name."
+          },
+          "phase": {
+            "type": "string",
+            "enum": ["prereq", "provision", "configure", "translate", "deploy", "verify", "cutover", "cleanup"],
+            "description": "Migration phase. prereq: checks and validations. provision: IaC deployment. configure: RBAC, identity, networking. translate: Ingress to Gateway API conversion. deploy: apply manifests. verify: test and validate. cutover: traffic switch. cleanup: remove old resources."
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed explanation of what this step does and why."
+          },
+          "preconditions": {
+            "type": "array",
+            "description": "Checks that must pass before executing this step.",
+            "items": {
+              "type": "object",
+              "required": ["check", "errorMessage"],
+              "additionalProperties": false,
+              "properties": {
+                "check": {
+                  "type": "string",
+                  "description": "Human-readable precondition (e.g., 'AGC private cluster support is GA in target region', 'Kubernetes version >= 1.28')."
+                },
+                "errorMessage": {
+                  "type": "string",
+                  "description": "Error message to display if the precondition fails."
+                },
+                "blockingLevel": {
+                  "type": "string",
+                  "enum": ["error", "warning"],
+                  "description": "Whether failure blocks step execution (error) or is advisory (warning)."
+                }
+              }
+            }
+          },
+          "actions": {
+            "type": "array",
+            "description": "Concrete actions to execute in this step.",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["type"],
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["command", "apply-manifest", "terraform", "bicep", "helm", "kubectl", "manual"],
+                  "description": "Action type. command: shell command. apply-manifest: kubectl apply. terraform/bicep: IaC. helm: Helm install/upgrade. kubectl: other kubectl operations. manual: human intervention required."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "What this action does."
+                },
+                "command": {
+                  "type": "string",
+                  "description": "Shell command to execute (for type=command)."
+                },
+                "manifestPath": {
+                  "type": "string",
+                  "description": "Path to manifest file (for type=apply-manifest, relative to plan root)."
+                },
+                "modulePath": {
+                  "type": "string",
+                  "description": "Path to Terraform or Bicep module (for type=terraform or bicep)."
+                },
+                "helmChart": {
+                  "type": "string",
+                  "description": "Helm chart reference (for type=helm, e.g., 'oci://mcr.microsoft.com/aks/alb/helm/alb-controller')."
+                },
+                "helmValues": {
+                  "type": "string",
+                  "description": "Path to Helm values file (for type=helm)."
+                },
+                "instructions": {
+                  "type": "string",
+                  "description": "Manual instructions (for type=manual)."
+                }
+              }
+            }
+          },
+          "rollback": {
+            "type": "object",
+            "description": "Rollback instructions if this step fails or must be reverted.",
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string",
+                "description": "How to undo this step."
+              },
+              "commands": {
+                "type": "array",
+                "description": "Shell commands to execute for rollback.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "verification": {
+            "type": "array",
+            "description": "Checks to verify this step completed successfully.",
+            "items": {
+              "type": "object",
+              "required": ["check"],
+              "additionalProperties": false,
+              "properties": {
+                "check": {
+                  "type": "string",
+                  "description": "Verification check (e.g., 'AGC frontend responds on HTTPS', 'HTTPRoute status is Accepted')."
+                },
+                "command": {
+                  "type": "string",
+                  "description": "Shell command to verify (e.g., 'kubectl get httproute hello-world -o jsonpath=.status.conditions')."
+                }
+              }
+            }
+          },
+          "dependsOn": {
+            "type": "array",
+            "description": "Step IDs that must complete before this step can start.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "risks": {
+      "type": "array",
+      "description": "Known risks and blockers for this migration plan.",
+      "items": {
+        "type": "object",
+        "required": ["id", "severity", "description"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Risk identifier (e.g., 'risk-01-agc-private-cluster-preview').",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "high", "medium", "low"],
+            "description": "Risk severity. critical: blocks migration. high: may cause outage. medium: degraded experience. low: minor impact."
+          },
+          "description": {
+            "type": "string",
+            "description": "What the risk is and why it matters."
+          },
+          "mitigation": {
+            "type": "string",
+            "description": "How to mitigate or work around this risk."
+          },
+          "relatedAdr": {
+            "type": "string",
+            "description": "Optional link to an ADR documenting this risk (e.g., 'docs/adr/ADR-003-agc-private-cluster-preview-gate.md')."
+          },
+          "relatedSteps": {
+            "type": "array",
+            "description": "Step IDs affected by this risk.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "tooling": {
+      "type": "object",
+      "description": "Tools and versions used to generate this plan. Supports ADR-001 wedge of orchestrating multiple upstream tools.",
+      "additionalProperties": false,
+      "properties": {
+        "ingress2gatewayVersion": {
+          "type": "string",
+          "description": "Version of kubernetes-sigs/ingress2gateway used for translation (e.g., 'v1.0.0')."
+        },
+        "azureMigrationUtilityVersion": {
+          "type": "string",
+          "description": "Version of Azure/Application-Gateway-for-Containers-Migration-Utility (if used)."
+        },
+        "runbookVersion": {
+          "type": "string",
+          "description": "Version of this repository's runbook (e.g., git commit SHA or tag)."
+        },
+        "generatedBy": {
+          "type": "string",
+          "description": "System or tool that generated the plan (e.g., 'mcp-server-azure-architect', 'manual')."
+        },
+        "additionalTools": {
+          "type": "object",
+          "description": "Other tools used in plan generation. Key is tool name, value is version string.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #18.

Adds the canonical "not an official Microsoft product" disclaimer to all customer-facing docs:
- `docs/_disclaimer.md` (canonical source)
- All three ADRs (001, 002, 003)
- `CONTRIBUTING.md`

Disclaimer text: *Not an official Microsoft product. Community migration toolkit. See LICENSE.*

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
