### PR TITLE
fix(ci): set GITHUB_TOKEN for gitleaks-action PR scans

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,4 +19,5 @@ jobs:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.7
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml


### PR DESCRIPTION
The gitleaks-action introduced a breaking change requiring GITHUB_TOKEN to be set explicitly when scanning pull requests. Without it, every PR fails CI with:

> GITHUB_TOKEN is now required to scan pull requests.

Adds the standard secrets.GITHUB_TOKEN injection. Permissions on the job stay scoped to contents: read since gitleaks only reads the diff.

This unblocks CI on all currently-open @copilot PRs (#23, #24, #25, #26, #27, #28, #35, #36) plus #39.

Validation: workflow file diff is one line; gitleaks-action documents this exact env var as required.