### PR TITLE
docs: add end-to-end migration runbook and nav index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,52 @@
+# aks-automatic-ingress-migration documentation
+
+Migration toolkit for AKS Automatic clusters moving from `ingress-nginx` and the App Routing addon to Gateway API plus Application Gateway for Containers (AGC).
+
+## Why
+
+- The community `ingress-nginx` project has announced retirement for **March 2026** ([kubernetes/ingress-nginx#10977](https://github.com/kubernetes/ingress-nginx/issues/10977), accessed 2026-04-22).
+- The Microsoft App Routing addon drops to critical-only patches in **November 2026** ([learn.microsoft.com/azure/aks/app-routing](https://learn.microsoft.com/azure/aks/app-routing), accessed 2026-04-22).
+- AKS Automatic ships ingress-nginx by default. Customers who do nothing will be on an unsupported controller.
+
+## How to use these docs
+
+Start at the runbook overview. Each phase is independently runnable and ends with explicit validation steps and a rollback path.
+
+| Path | What you get |
+|---|---|
+| [Architecture decisions](./adr/) | ADR-001 positioning, ADR-002 Bicep+Terraform parity contract, ADR-003 AGC private cluster preview gate |
+| [Migration runbook](./runbook/00-overview.md) | 10-phase end-to-end runbook from assessment to rollback |
+| [Quickstart sample](../examples/hello-world/README.md) | Smallest reproducible AGC + Gateway API + Workload Identity demo, ALZ Corp defaults |
+| [Migration helper scripts](../scripts/migration/README.md) | PowerShell cmdlets for assessment, conversion, and traffic cutover |
+| [Presentation deck](../presentation/README.md) | reveal.js HTML deck for internal briefings |
+
+## Default architecture posture
+
+All examples assume:
+
+- ALZ Corp landing zone topology (hub-spoke with central Azure Firewall egress).
+- AKS Automatic with **private API server**.
+- **No public IPs** on the cluster or AGC frontend (`azure-alb-internal`).
+- **Workload Identity** for in-cluster identity. No service principal secrets.
+- **AGC managed identity** for the ALB controller. No SP secrets.
+
+If your environment differs, every Terraform module and Bicep file exposes overrides. The defaults are the safest path for regulated customers.
+
+## Validation gates
+
+Every code change must pass these before merge:
+
+```powershell
+terraform fmt -check -recursive
+terraform validate
+az bicep build --file <file>
+helm lint charts/*
+kubectl --dry-run=client apply -f manifests/
+pwsh scripts/validate-iac-parity.ps1
+```
+
+CI enforces the same gates on every PR. See [`.github/workflows/`](../.github/workflows/).
+
+## Contributing
+
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md). Issues labeled `squad` go to Lead for triage; named owners pick up `squad:{name}` labels.

--- a/docs/runbook/00-overview.md
+++ b/docs/runbook/00-overview.md
@@ -1,0 +1,57 @@
+# Phase 00 — Overview and preflight
+
+## Goal
+
+Establish a shared mental model for the migration, confirm timelines, and verify the operator's environment is ready to begin.
+
+## Mental model shift
+
+| Concept | ingress-nginx world | Gateway API + AGC world |
+|---|---|---|
+| Routing object | `Ingress` (single resource, vendor annotations) | `Gateway` (infra owner) + `HTTPRoute` (app owner) |
+| Controller | `ingress-nginx-controller` Deployment in cluster | `alb-controller` in `azure-alb-system` plus Azure-managed AGC dataplane |
+| Frontend | LoadBalancer Service with public or internal IP | AGC frontend with FQDN, public or `azure-alb-internal` |
+| TLS | `Ingress.spec.tls`, cert-manager | `Gateway.spec.listeners[].tls.certificateRefs` to `Secret` (Gateway API v1) |
+| Annotation behaviour | NGINX-specific, snippets, lua | First-class spec fields, filters, BackendTrafficPolicy |
+| Identity | SP secret in cluster typical | Workload Identity for app, managed identity for controller |
+
+## Preflight checklist
+
+Before starting Phase 01, confirm:
+
+- [ ] You have **Owner** or equivalent on the AKS cluster's resource group (needed for managed identity assignments and AGC association).
+- [ ] You have **Network Contributor** on the spoke VNet (needed for AGC subnet delegation).
+- [ ] AKS cluster is on a supported Kubernetes version (see [AKS supported versions](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions), accessed 2026-04-22).
+- [ ] `kubectl`, `helm`, `az` (with `aks-preview` extension), `terraform >= 1.6`, `pwsh >= 7.4` are on PATH.
+- [ ] `ingress2gateway` >= 0.3.0 is on PATH ([upstream releases](https://github.com/kubernetes-sigs/ingress2gateway/releases), accessed 2026-04-22).
+- [ ] Read [ADR-003](../adr/ADR-003-agc-private-cluster-preview-gate.md). If your cluster is private and AGC private cluster support is still in preview in your region, you may need a public bastion path for validation.
+
+## Timeline assumption
+
+Plan for **3-6 calendar months** end-to-end for an ALZ Corp environment with realistic change windows, security review, and DR cutover testing. Phases are sized so each can be paused and resumed without leaving the cluster in an unhealthy state.
+
+## What this runbook does NOT cover
+
+- Migration off Application Gateway Ingress Controller (AGIC). AGIC users have a separate, simpler path documented at [learn.microsoft.com/azure/application-gateway/for-containers/migrate-from-agic-to-agc](https://learn.microsoft.com/azure/application-gateway/for-containers/migrate-from-agic-to-agc) (accessed 2026-04-22).
+- Service Mesh integration (Istio, Linkerd). AGC supports `BackendTLSPolicy` for upstream mTLS but mesh sidecar coexistence is out of scope.
+- Multi-cluster fleet routing.
+
+## Phases at a glance
+
+| Phase | Outcome |
+|---|---|
+| [01](./01-assess-current-ingress.md) | Inventory of every Ingress in the cluster with annotation risk classification |
+| [02](./02-provision-agc-base.md) | AGC base infrastructure deployed via Terraform or Bicep, parity-checked |
+| [03](./03-identity-wiring.md) | Workload Identity federation for the ALB controller and app workloads |
+| [04](./04-translate-manifests.md) | Ingress manifests translated to Gateway + HTTPRoute via `ingress2gateway` plus manual fixes |
+| [05](./05-network-and-dns.md) | Network policies, DNS strategy, and cert lifecycle aligned with the new frontend |
+| [06](./06-shadow-traffic.md) | New AGC frontend serving real traffic in shadow mode for observation |
+| [07](./07-cutover.md) | Production cutover, weighted or DNS-flip |
+| [08](./08-decommission.md) | App Routing addon disabled, ingress-nginx Helm release removed, leftover resources cleaned |
+| [09](./09-rollback.md) | Documented reverse path at any phase |
+
+## References
+
+- [AKS Automatic overview](https://learn.microsoft.com/azure/aks/intro-aks-automatic) (accessed 2026-04-22)
+- [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) (accessed 2026-04-22)
+- [Gateway API v1.0 GA announcement](https://kubernetes.io/blog/2023/10/31/gateway-api-ga/) (accessed 2026-04-22)

--- a/docs/runbook/01-assess-current-ingress.md
+++ b/docs/runbook/01-assess-current-ingress.md
@@ -1,0 +1,84 @@
+# Phase 01 — Assess current ingress estate
+
+## Goal
+
+Produce a complete inventory of every `Ingress` object in the cluster with each annotation classified as **portable**, **manual-fix**, or **blocker**. No resources are modified in this phase.
+
+## Prerequisites
+
+- Read access to every namespace in the cluster (`get,list` on `ingresses.networking.k8s.io`).
+- `kubectl` configured with cluster context.
+- `pwsh >= 7.4`.
+
+## Steps
+
+### 1. Capture the Ingress inventory
+
+```bash
+kubectl get ingress -A -o json > ingress-inventory.json
+```
+
+Verify count:
+
+```bash
+kubectl get ingress -A --no-headers | wc -l
+```
+
+### 2. Run the assessment cmdlet
+
+The repo ships a PowerShell helper that classifies every annotation against the `ingress2gateway` translation matrix and ALZ Corp policy.
+
+```powershell
+Import-Module ./scripts/migration/module.psd1
+Get-MigrationAssessment -InputPath ./ingress-inventory.json -OutputPath ./assessment.json
+```
+
+Output schema:
+
+```json
+{
+  "totalIngresses": 12,
+  "byClass": { "nginx": 10, "webapprouting.kubernetes.azure.com": 2 },
+  "annotations": {
+    "portable":    [ /* directly translated by ingress2gateway */ ],
+    "manualFix":   [ /* needs HTTPRoute filter or BackendTrafficPolicy */ ],
+    "blockers":    [ /* no AGC equivalent, redesign required */ ]
+  },
+  "tlsSecrets":   [ /* secrets referenced by Ingress.spec.tls */ ],
+  "backendServices": [ /* unique Service refs */ ]
+}
+```
+
+### 3. Triage blockers
+
+Common blockers and recommended action:
+
+| Annotation | Recommended action |
+|---|---|
+| `nginx.ingress.kubernetes.io/configuration-snippet` | Rewrite intent as `HTTPRoute` filter or `BackendTrafficPolicy`, or move logic to the application |
+| `nginx.ingress.kubernetes.io/server-snippet` | As above |
+| `nginx.ingress.kubernetes.io/auth-url` | Move to AGC `BackendTLSPolicy` + external auth, or use OIDC at AGC frontend |
+| `nginx.ingress.kubernetes.io/canary*` | Use HTTPRoute weighted backendRefs (Gateway API native) |
+| `nginx.ingress.kubernetes.io/rewrite-target` (regex) | Translate to HTTPRoute `URLRewrite` filter, validate edge cases |
+| `nginx.ingress.kubernetes.io/proxy-body-size` | Set on `BackendTrafficPolicy.timeouts` or accept AGC default |
+
+See [Ingress to Gateway API translation](https://gateway-api.sigs.k8s.io/guides/migrating-from-ingress/) (accessed 2026-04-22) and [AGC supported policies](https://learn.microsoft.com/azure/application-gateway/for-containers/api-specification-kubernetes) (accessed 2026-04-22).
+
+### 4. Stakeholder review
+
+Email or post the assessment to each app team that owns a blocker. Block on their decision before Phase 04.
+
+## Validation
+
+- [ ] `assessment.json` exists and lists every Ingress.
+- [ ] Every annotation in the cluster appears in exactly one of the three buckets.
+- [ ] App owners have acknowledged any `blockers` entries.
+
+## Rollback
+
+This phase is read-only. No rollback needed.
+
+## References
+
+- [`Get-MigrationAssessment` source](../../scripts/migration/Get-MigrationAssessment.ps1)
+- [`ingress2gateway` annotation matrix](https://github.com/kubernetes-sigs/ingress2gateway/blob/main/pkg/i2gw/providers/ingressnginx/converter.go) (accessed 2026-04-22)

--- a/docs/runbook/02-provision-agc-base.md
+++ b/docs/runbook/02-provision-agc-base.md
@@ -1,0 +1,115 @@
+# Phase 02 — Provision AGC base infrastructure
+
+## Goal
+
+Deploy the AGC dataplane (Application Load Balancer resource, frontend, association) and ALB controller subnet using the parity-checked Terraform or Bicep modules in this repo. Do not yet wire identity (Phase 03) or routes (Phase 04).
+
+## Prerequisites
+
+- Phase 01 complete.
+- Resource group exists in the spoke subscription.
+- A spoke VNet with **at least one /24 subnet free** for the AGC association ([sizing reference](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller#prerequisites), accessed 2026-04-22).
+- Owner on the resource group and Network Contributor on the VNet.
+- Read [ADR-003](../adr/ADR-003-agc-private-cluster-preview-gate.md) and confirm AGC private cluster status in your region.
+
+## Steps
+
+### Option A: Terraform
+
+```bash
+cd infra/terraform/agc
+cat > terraform.tfvars <<EOF
+location            = "westeurope"
+resource_group_name = "rg-aks-prod-spoke"
+agc_name            = "agc-aks-prod"
+vnet_name           = "vnet-spoke-prod"
+subnet_id           = "/subscriptions/.../subnets/snet-agc"
+EOF
+
+terraform init
+terraform plan -out=tfplan
+# review plan, then:
+terraform apply tfplan
+```
+
+Outputs (parity contract per ADR-002):
+
+```text
+alb_id, alb_name, frontend_id, frontend_fqdn, association_id
+```
+
+### Option B: Bicep
+
+```bash
+cd infra/bicep/agc
+az deployment group what-if \
+  --resource-group rg-aks-prod-spoke \
+  --template-file main.bicep \
+  --parameters \
+      location=westeurope \
+      agcName=agc-aks-prod \
+      vnetName=vnet-spoke-prod \
+      subnetId=/subscriptions/.../subnets/snet-agc
+
+# review what-if, then:
+az deployment group create \
+  --resource-group rg-aks-prod-spoke \
+  --template-file main.bicep \
+  --parameters @params.json
+```
+
+### 3. Verify parity
+
+The repo's parity validator confirms Terraform and Bicep emit identical output names per [ADR-002](../adr/ADR-002-bicep-terraform-parity-contract.md):
+
+```powershell
+pwsh scripts/validate-iac-parity.ps1 `
+  -SchemaPath infra/agc/outputs.schema.json `
+  -TerraformModulePath infra/terraform/agc `
+  -BicepModulePath infra/bicep/agc
+```
+
+### 4. Install the ALB Controller (no identity yet)
+
+Identity wiring is Phase 03. Install the controller now with placeholder identity:
+
+```bash
+helm install alb-controller oci://mcr.microsoft.com/application-lb/charts/alb-controller \
+  --namespace azure-alb-system --create-namespace \
+  --version 1.6.0 \
+  --set albController.podIdentity.clientID=00000000-0000-0000-0000-000000000000
+```
+
+Pods will start but log identity errors until Phase 03 completes. This is expected.
+
+## Validation
+
+- [ ] `az network alb show -g <rg> -n <agc-name>` returns provisioning state `Succeeded`.
+- [ ] `kubectl get pods -n azure-alb-system` shows controller pods running (may be `CrashLoopBackOff` due to missing identity, that is OK).
+- [ ] `terraform output frontend_fqdn` (or Bicep equivalent) returns a non-empty FQDN.
+- [ ] `pwsh scripts/validate-iac-parity.ps1` exits 0.
+
+## Rollback
+
+```bash
+# Terraform
+cd infra/terraform/agc && terraform destroy
+
+# Bicep
+az deployment group create \
+  --resource-group rg-aks-prod-spoke \
+  --template-file main.bicep \
+  --mode Complete \
+  --parameters agcName=agc-aks-prod
+# Or delete by RG if isolated.
+
+helm uninstall alb-controller -n azure-alb-system
+kubectl delete namespace azure-alb-system
+```
+
+No production traffic is on AGC at this phase, so destroy is safe.
+
+## References
+
+- [AGC quickstart, ALB controller-managed](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller) (accessed 2026-04-22)
+- [ADR-002 Bicep+Terraform parity contract](../adr/ADR-002-bicep-terraform-parity-contract.md)

--- a/docs/runbook/03-identity-wiring.md
+++ b/docs/runbook/03-identity-wiring.md
@@ -1,0 +1,124 @@
+# Phase 03 — Identity wiring
+
+## Goal
+
+Federate the ALB controller's Kubernetes ServiceAccount to the AGC managed identity using Workload Identity. No service principal secrets in the cluster.
+
+## Prerequisites
+
+- Phase 02 complete (controller installed, AGC provisioned).
+- AKS Automatic cluster has **OIDC issuer enabled** and **Workload Identity enabled** (default for Automatic, confirm with `az aks show -g <rg> -n <cluster> --query oidcIssuerProfile`).
+- The user-assigned managed identity for AGC was created by the IaC modules. Note its `clientId` and the `principalId` from Phase 02 outputs.
+
+## Steps
+
+### 1. Capture cluster OIDC issuer
+
+```bash
+OIDC_ISSUER=$(az aks show -g <rg> -n <cluster> \
+  --query oidcIssuerProfile.issuerUrl -o tsv)
+echo "$OIDC_ISSUER"
+```
+
+### 2. Create federated credential for the ALB controller ServiceAccount
+
+```bash
+AGC_IDENTITY_NAME="id-agc-aks-prod"
+RG="rg-aks-prod-spoke"
+
+az identity federated-credential create \
+  --name "alb-controller-fed" \
+  --identity-name "$AGC_IDENTITY_NAME" \
+  --resource-group "$RG" \
+  --issuer "$OIDC_ISSUER" \
+  --subject "system:serviceaccount:azure-alb-system:alb-controller-sa" \
+  --audience "api://AzureADTokenExchange"
+```
+
+### 3. Grant AGC permissions to the managed identity
+
+```bash
+SUB=$(az account show --query id -o tsv)
+AGC_RG_SCOPE="/subscriptions/$SUB/resourceGroups/$RG"
+AGC_PRINCIPAL_ID=$(az identity show -g "$RG" -n "$AGC_IDENTITY_NAME" --query principalId -o tsv)
+
+# Required by ALB controller, per MS docs
+az role assignment create \
+  --assignee-object-id "$AGC_PRINCIPAL_ID" --assignee-principal-type ServicePrincipal \
+  --scope "$AGC_RG_SCOPE" \
+  --role "AppGw for Containers Configuration Manager"
+
+# Reader on the AGC association (subnet)
+SUBNET_ID="/subscriptions/.../subnets/snet-agc"
+az role assignment create \
+  --assignee-object-id "$AGC_PRINCIPAL_ID" --assignee-principal-type ServicePrincipal \
+  --scope "$SUBNET_ID" \
+  --role "Network Contributor"
+```
+
+### 4. Annotate the controller ServiceAccount
+
+```bash
+CLIENT_ID=$(az identity show -g "$RG" -n "$AGC_IDENTITY_NAME" --query clientId -o tsv)
+
+kubectl annotate serviceaccount alb-controller-sa \
+  -n azure-alb-system \
+  azure.workload.identity/client-id="$CLIENT_ID" \
+  --overwrite
+
+kubectl label serviceaccount alb-controller-sa \
+  -n azure-alb-system \
+  azure.workload.identity/use=true \
+  --overwrite
+```
+
+### 5. Restart the controller to pick up the token
+
+```bash
+kubectl rollout restart deployment/alb-controller -n azure-alb-system
+kubectl rollout status deployment/alb-controller -n azure-alb-system --timeout=120s
+```
+
+### 6. App workload Workload Identity (per app)
+
+For each application that will receive traffic, repeat the federated credential pattern:
+
+```bash
+az identity federated-credential create \
+  --name "<app>-fed" \
+  --identity-name "<app-managed-identity>" \
+  --resource-group "$RG" \
+  --issuer "$OIDC_ISSUER" \
+  --subject "system:serviceaccount:<ns>:<sa>" \
+  --audience "api://AzureADTokenExchange"
+```
+
+Annotate the app's ServiceAccount with `azure.workload.identity/client-id` and label `azure.workload.identity/use=true`.
+
+## Validation
+
+- [ ] `kubectl logs -n azure-alb-system deployment/alb-controller --tail=50` shows no `AADSTS` errors.
+- [ ] Controller log includes `Successfully registered with AGC resource <agc-id>`.
+- [ ] `kubectl get pods -n azure-alb-system` all pods `Running`, no `CrashLoopBackOff`.
+- [ ] No long-lived secrets exist in `azure-alb-system` (`kubectl get secret -n azure-alb-system` shows only ServiceAccount tokens).
+
+## Rollback
+
+```bash
+az identity federated-credential delete \
+  --name "alb-controller-fed" \
+  --identity-name "$AGC_IDENTITY_NAME" \
+  --resource-group "$RG" --yes
+
+kubectl annotate serviceaccount alb-controller-sa -n azure-alb-system \
+  azure.workload.identity/client-id-
+
+# (optional) revert role assignments
+az role assignment delete --assignee "$AGC_PRINCIPAL_ID" --scope "$AGC_RG_SCOPE" \
+  --role "AppGw for Containers Configuration Manager"
+```
+
+## References
+
+- [Workload Identity overview](https://learn.microsoft.com/azure/aks/workload-identity-overview) (accessed 2026-04-22)
+- [ALB controller install with Workload Identity](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller) (accessed 2026-04-22)

--- a/docs/runbook/04-translate-manifests.md
+++ b/docs/runbook/04-translate-manifests.md
@@ -1,0 +1,123 @@
+# Phase 04 — Translate Ingress manifests to Gateway + HTTPRoute
+
+## Goal
+
+Generate `Gateway`, `HTTPRoute`, and supporting policy manifests from the existing `Ingress` inventory using `ingress2gateway`, then patch the gaps that the tool cannot translate.
+
+## Prerequisites
+
+- Phase 01 assessment complete (`assessment.json` on disk).
+- Phase 02 AGC provisioned, controller healthy with identity.
+- `ingress2gateway >= 0.3.0` on PATH.
+- A `gateways/` working directory.
+
+## Steps
+
+### 1. Run the bulk converter
+
+The `Convert-IngressToGateway` cmdlet wraps `ingress2gateway` with the AGC GatewayClass and emits per-namespace files.
+
+```powershell
+Import-Module ./scripts/migration/module.psd1
+
+Convert-IngressToGateway `
+  -InputPath ./ingress-inventory.json `
+  -OutputDirectory ./gateways `
+  -GatewayClassName "azure-alb-external" `
+  -ListenerProtocol "HTTPS" `
+  -DryRun
+```
+
+Output structure:
+
+```text
+gateways/
+  <namespace>/
+    gateway.yaml
+    httproute-<ingress-name>.yaml
+  unsupported.md   # human-readable list of skipped annotations
+```
+
+Re-run without `-DryRun` to actually write files.
+
+### 2. Choose your Gateway topology
+
+Decide before Phase 06 which topology you want. AGC supports both:
+
+| Topology | When to use |
+|---|---|
+| **Shared Gateway** per cluster (one `Gateway` in a platform namespace, app teams attach `HTTPRoute` via `parentRefs`) | Cost-optimised, central frontend cert mgmt, ALZ Corp default |
+| **Gateway per namespace** | Strong tenant isolation, multi-tenant clusters with hard boundaries |
+
+For ALZ Corp, prefer shared. The hello-world sample uses shared.
+
+### 3. Internal vs external frontend
+
+Set the GatewayClass and `infrastructure.annotations` to control public exposure:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-internal
+  namespace: gateway-system
+spec:
+  gatewayClassName: azure-alb-internal
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: tls-cert
+```
+
+Default for ALZ Corp is **`azure-alb-internal`** (no public IP).
+
+### 4. Patch unsupported annotations
+
+For each entry in `unsupported.md`, apply one of the patterns from [Phase 01 triage](./01-assess-current-ingress.md#3-triage-blockers). Common patterns:
+
+- **Canary / weighted traffic**: convert to `HTTPRoute.spec.rules[].backendRefs[].weight`.
+- **Header rewrite**: add `HTTPRoute.spec.rules[].filters[]` of type `RequestHeaderModifier`.
+- **Path rewrite**: add `URLRewrite` filter.
+- **Body size limit**: create a `BackendTrafficPolicy` per AGC docs.
+- **mTLS to backend**: create a `BackendTLSPolicy` referring to a `ConfigMap` with the CA bundle.
+
+### 5. Lint the generated manifests
+
+```bash
+kubectl apply --dry-run=client -f gateways/ -R
+```
+
+For static schema validation:
+
+```bash
+kubeconform -strict -kubernetes-version 1.30.0 \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+  $(find gateways -name '*.yaml')
+```
+
+## Validation
+
+- [ ] Every `Ingress` from the inventory has a corresponding `HTTPRoute` (or is documented as intentionally dropped in `unsupported.md`).
+- [ ] `kubectl apply --dry-run=client` exits 0.
+- [ ] `kubeconform` exits 0.
+- [ ] No `HTTPRoute` references a backend `Service` that does not exist (use the `backendServices` list from Phase 01 to cross-check).
+
+## Rollback
+
+The generated files are in `./gateways/` and not yet applied to the cluster. To rollback, delete the directory.
+
+```powershell
+Remove-Item -Recurse -Force ./gateways
+```
+
+## References
+
+- [`ingress2gateway` README](https://github.com/kubernetes-sigs/ingress2gateway) (accessed 2026-04-22)
+- [Gateway API HTTPRoute spec](https://gateway-api.sigs.k8s.io/api-types/httproute/) (accessed 2026-04-22)
+- [AGC API spec for Kubernetes (BackendTrafficPolicy, BackendTLSPolicy, HealthCheckPolicy)](https://learn.microsoft.com/azure/application-gateway/for-containers/api-specification-kubernetes) (accessed 2026-04-22)

--- a/docs/runbook/05-network-and-dns.md
+++ b/docs/runbook/05-network-and-dns.md
@@ -1,0 +1,127 @@
+# Phase 05 — Network policies, DNS, and certs
+
+## Goal
+
+Align cluster network policies with the new AGC frontend, plan the DNS strategy for cutover, and migrate TLS certificate references from `Ingress.spec.tls` to Gateway listener `certificateRefs`.
+
+## Prerequisites
+
+- Phase 04 manifests generated and linted (not yet applied).
+- DNS authority for the customer-facing hostnames.
+- Cert source: Azure Key Vault, cert-manager, or pre-staged Kubernetes Secrets.
+
+## Steps
+
+### 1. Network policies
+
+If the cluster runs network policies (Cilium on AKS Automatic by default), allow ingress to backend Services from the AGC subnet rather than from `ingress-nginx-controller` pod CIDR.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-agc
+  namespace: <app-ns>
+spec:
+  podSelector:
+    matchLabels:
+      app: <app>
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.x.y.0/24
+      ports:
+        - protocol: TCP
+          port: 8080
+```
+
+Keep the existing `allow-from-nginx` policy in place until Phase 08 to avoid blocking traffic during shadow / cutover.
+
+### 2. Cluster egress (Azure Firewall allow-list)
+
+AGC is a managed dataplane. The ALB controller in the cluster needs egress to:
+
+- `*.management.azure.com` (ARM)
+- `*.servicebus.windows.net` (controller telemetry)
+- The Azure AD endpoints (`login.microsoftonline.com`, etc.)
+
+If your hub Azure Firewall application rule collection blocks these, add an allow rule scoped to the AKS subnet.
+
+### 3. DNS strategy
+
+You have three viable patterns:
+
+| Pattern | Pros | Cons |
+|---|---|---|
+| **A. Add new FQDN** (e.g., `app-agc.contoso.com`), validate in shadow, then DNS-flip the original `app.contoso.com` to AGC | Lowest risk, easy rollback | Two endpoints during transition |
+| **B. Weighted DNS records** (Azure Traffic Manager weighted routing) | Gradual cutover, observable | Cache TTL effects, slower rollback |
+| **C. Same hostname, both controllers attached** (impossible if both bind same Service IP, but valid for distinct frontends) | Simplest | DNS race conditions |
+
+ALZ Corp default: **Pattern A**. Pattern B is acceptable for high-criticality apps where an instant cutover is unacceptable.
+
+### 4. TLS certificates
+
+For each TLS-bearing Ingress, decide cert source:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+spec:
+  listeners:
+    - name: https
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: app-tls
+```
+
+cert-manager has supported Gateway API since v1.12. Add the `--enable-gateway-api` flag and create `Certificate` resources that target the new `Gateway`. See [cert-manager Gateway API docs](https://cert-manager.io/docs/usage/gateway/) (accessed 2026-04-22).
+
+For Azure Key Vault certs, mount via Secrets Store CSI driver and `secretObjects` to materialise as a Kubernetes Secret. The ALB controller does **not** read directly from Key Vault.
+
+### 5. Health probes
+
+If your Ingress used custom probe paths via `nginx.ingress.kubernetes.io/healthcheck-path`, translate to `HealthCheckPolicy`:
+
+```yaml
+apiVersion: alb.networking.azure.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: app-health
+  namespace: <app-ns>
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: <service>
+  default:
+    interval: 5s
+    timeout: 3s
+    healthyThreshold: 1
+    unhealthyThreshold: 3
+    http:
+      path: /healthz
+      port: 8080
+```
+
+## Validation
+
+- [ ] DNS records for the new endpoint (Pattern A) or weighted records (Pattern B) are created with **low TTL (60s)** to enable fast cutover and rollback.
+- [ ] All `Gateway.listeners[].tls.certificateRefs` resolve to existing `Secrets` in the same namespace as the Gateway.
+- [ ] NetworkPolicy `allow-from-agc` applied in every app namespace.
+- [ ] Azure Firewall log shows no DENY entries from AKS subnet to AGC management endpoints.
+
+## Rollback
+
+This phase only adds DNS records and NetworkPolicies. To rollback:
+
+- Delete added DNS records.
+- `kubectl delete networkpolicy allow-from-agc -n <ns>`.
+- TLS Secrets can stay; they are unused until the Gateway references them.
+
+## References
+
+- [cert-manager Gateway API support](https://cert-manager.io/docs/usage/gateway/) (accessed 2026-04-22)
+- [Secrets Store CSI driver on AKS](https://learn.microsoft.com/azure/aks/csi-secrets-store-driver) (accessed 2026-04-22)
+- [AGC HealthCheckPolicy spec](https://learn.microsoft.com/azure/application-gateway/for-containers/custom-health-probe) (accessed 2026-04-22)

--- a/docs/runbook/06-shadow-traffic.md
+++ b/docs/runbook/06-shadow-traffic.md
@@ -1,0 +1,119 @@
+# Phase 06 — Shadow traffic and observation
+
+## Goal
+
+Apply the generated `Gateway` and `HTTPRoute` manifests to the cluster, point synthetic and real-but-low-stakes traffic at the new AGC frontend, and observe for parity with the legacy `ingress-nginx` path. **No production cutover yet.**
+
+## Prerequisites
+
+- Phase 04 manifests generated.
+- Phase 05 NetworkPolicies and TLS Secrets in place.
+- New DNS records (Pattern A) or weighted records (Pattern B) created.
+- Observability stack collecting AGC metrics (Azure Monitor for Containers, or Prometheus scraping the controller).
+
+## Steps
+
+### 1. Apply manifests in dependency order
+
+```bash
+kubectl apply -f gateways/<gateway-namespace>/gateway.yaml
+
+kubectl wait --for=condition=Programmed gateway/<name> \
+  -n <gateway-namespace> --timeout=180s
+
+kubectl apply -R -f gateways/
+```
+
+### 2. Verify Gateway is healthy
+
+```bash
+kubectl get gateway -A -o wide
+kubectl describe gateway <name> -n <gateway-namespace>
+```
+
+Look for:
+
+```text
+Conditions:
+  Type: Accepted          Status: True
+  Type: Programmed        Status: True
+Listeners:
+  - Name: https
+    Conditions:
+      Accepted: True
+      ResolvedRefs: True
+```
+
+### 3. Smoke test from a pod inside the cluster
+
+```bash
+kubectl run curl-test --image=curlimages/curl --rm -it --restart=Never -- \
+  curl -sS -H "Host: app.contoso.com" https://<agc-frontend-fqdn>/healthz
+```
+
+### 4. Smoke test from on-prem or jumpbox
+
+```bash
+curl -sS https://app-agc.contoso.com/healthz
+```
+
+If using `azure-alb-internal`, this requires connectivity from a peered VNet, ExpressRoute, or VPN.
+
+### 5. Synthetic shadow traffic
+
+Run the smoke workflow committed at `.github/workflows/smoke-test.yml` against the new endpoint:
+
+```bash
+gh workflow run smoke-test.yml \
+  -f endpoint=https://app-agc.contoso.com \
+  -f duration=300
+```
+
+The workflow captures p50/p95/p99 latency and error rate.
+
+### 6. Compare with legacy
+
+Pull the same metrics window for the existing `ingress-nginx` endpoint. Acceptance criteria:
+
+| Metric | Threshold |
+|---|---|
+| 5xx rate | within +0.1% of legacy |
+| p95 latency | within +20ms of legacy |
+| Connection errors | 0 |
+| Cert handshake errors | 0 |
+
+If any threshold fails, do not proceed to Phase 07. Iterate on Phase 04 / 05 fixes.
+
+### 7. Run the migration helper preflight
+
+```powershell
+Import-Module ./scripts/migration/module.psd1
+
+Invoke-TrafficCutover -DryRun `
+  -LegacyEndpoint https://app.contoso.com `
+  -NewEndpoint https://app-agc.contoso.com `
+  -RampPercent 0
+```
+
+The cmdlet probes both endpoints and refuses to print a real cutover plan if shadow parity is not met.
+
+## Validation
+
+- [ ] All Gateways report `Programmed: True`.
+- [ ] All HTTPRoutes report `Accepted: True` and `ResolvedRefs: True`.
+- [ ] Shadow smoke-test workflow run is green for at least **24 hours**.
+- [ ] Comparison metrics are within thresholds.
+- [ ] No new alerts in Azure Monitor for the AGC association resource.
+
+## Rollback
+
+```bash
+kubectl delete -R -f gateways/
+```
+
+This removes the AGC routing without touching the legacy `ingress-nginx` path. Production traffic is unaffected because no DNS flip has happened.
+
+## References
+
+- [AGC observability](https://learn.microsoft.com/azure/application-gateway/for-containers/monitor-application-gateway-for-containers) (accessed 2026-04-22)
+- [Gateway API status conditions](https://gateway-api.sigs.k8s.io/concepts/conformance/) (accessed 2026-04-22)

--- a/docs/runbook/07-cutover.md
+++ b/docs/runbook/07-cutover.md
@@ -1,0 +1,111 @@
+# Phase 07 — Production cutover
+
+## Goal
+
+Move production traffic from `ingress-nginx` (or the App Routing addon) to the AGC frontend. Choose between an instant DNS flip or a weighted ramp.
+
+## Prerequisites
+
+- Phase 06 shadow validation passed at thresholds for **at least 24 hours**.
+- Change advisory board (CAB) approval if your org requires it.
+- Communication sent to dependent teams.
+- Rollback plan reviewed (Phase 09).
+
+## Steps
+
+### Option A: DNS flip (Pattern A from Phase 05)
+
+This is the ALZ Corp default. Single CNAME swap, instant rollback.
+
+#### 1. Lower TTL further (24 hours before cutover)
+
+If TTL is currently 60s, leave it. If higher, lower it the day before:
+
+```bash
+az network dns record-set cname update \
+  --resource-group <dns-rg> \
+  --zone-name contoso.com \
+  --name app \
+  --set ttl=30
+```
+
+#### 2. Execute the flip
+
+```bash
+az network dns record-set cname set-record \
+  --resource-group <dns-rg> \
+  --zone-name contoso.com \
+  --record-set-name app \
+  --cname <agc-frontend-fqdn>
+```
+
+Or via the helper cmdlet, which validates both endpoints first:
+
+```powershell
+Import-Module ./scripts/migration/module.psd1
+
+Invoke-TrafficCutover `
+  -LegacyEndpoint https://app.contoso.com `
+  -NewEndpoint https://app-agc.contoso.com `
+  -DnsZoneResourceGroup <dns-rg> `
+  -DnsZoneName contoso.com `
+  -RecordSetName app `
+  -TargetCname <agc-frontend-fqdn>
+```
+
+#### 3. Watch dashboards
+
+- AGC association metric: `RequestCount` should ramp from low (shadow) to legacy levels within ~1-2 minutes (resolver TTL plus client cache).
+- `ingress-nginx-controller` metric: `nginx_ingress_controller_requests` should fall toward 0.
+- App-level error rate: should remain flat.
+
+### Option B: Weighted ramp (Pattern B from Phase 05)
+
+Use Azure Traffic Manager Weighted profile. Pre-create endpoints for both legacy and AGC.
+
+```bash
+# Ramp 5% to AGC
+az network traffic-manager endpoint update \
+  --profile-name app-tm --resource-group <rg> \
+  --name agc --type externalEndpoints --weight 5
+
+az network traffic-manager endpoint update \
+  --profile-name app-tm --resource-group <rg> \
+  --name nginx --type externalEndpoints --weight 95
+
+# Wait 30 minutes, observe, then bump to 25%, 50%, 100%
+```
+
+The helper cmdlet supports ramp:
+
+```powershell
+Invoke-TrafficCutover `
+  -LegacyEndpoint https://app.contoso.com `
+  -NewEndpoint https://app-agc.contoso.com `
+  -RampPercent 5 `
+  -TrafficManagerProfile app-tm `
+  -TrafficManagerResourceGroup <rg>
+```
+
+Repeat with `-RampPercent 25`, `50`, `100` over the cutover window.
+
+### 3. Soak
+
+After 100% on AGC, soak for **at least 7 days** before Phase 08. Do not decommission ingress-nginx during the soak; it must remain available for fast rollback.
+
+## Validation
+
+- [ ] Hostname resolves to AGC frontend (`dig +short app.contoso.com`).
+- [ ] AGC association `RequestCount` matches historical baseline.
+- [ ] `nginx_ingress_controller_requests` rate is at or near zero.
+- [ ] No spike in 5xx, latency p95, or cert errors during ramp.
+- [ ] On-call team has acknowledged the cutover and knows the rollback command.
+
+## Rollback
+
+See [Phase 09](./09-rollback.md). For Option A, the rollback is a single `az network dns record-set cname set-record` back to the original target. For Option B, set the AGC endpoint weight back to 0.
+
+## References
+
+- [Azure DNS record TTL](https://learn.microsoft.com/azure/dns/dns-zones-records) (accessed 2026-04-22)
+- [Azure Traffic Manager weighted routing](https://learn.microsoft.com/azure/traffic-manager/traffic-manager-routing-methods#weighted) (accessed 2026-04-22)

--- a/docs/runbook/08-decommission.md
+++ b/docs/runbook/08-decommission.md
@@ -1,0 +1,117 @@
+# Phase 08 — Decommission ingress-nginx and the App Routing addon
+
+## Goal
+
+Remove the legacy ingress controller, the App Routing addon (if used), and any orphaned resources. Lock the cluster against accidental ingress-nginx reinstall.
+
+## Prerequisites
+
+- Phase 07 cutover at 100% AGC for **at least 7 days** with no incidents.
+- All Ingress objects removed from the cluster (or annotated for archival).
+- Stakeholders notified.
+- A point-in-time **etcd backup** exists. AKS Automatic snapshots etcd; confirm with platform team.
+
+## Steps
+
+### 1. Inventory remaining Ingress objects
+
+```bash
+kubectl get ingress -A
+```
+
+There should be none. If any remain, return to Phase 04.
+
+### 2. Disable the App Routing addon (if enabled)
+
+```bash
+az aks approuting disable -g <rg> -n <cluster> --yes
+```
+
+This removes the addon-managed `app-routing-system` namespace and the addon's controller.
+
+### 3. Uninstall manually-installed ingress-nginx (if Helm)
+
+```bash
+helm uninstall ingress-nginx -n ingress-nginx
+kubectl delete namespace ingress-nginx --wait=true
+```
+
+If installed via Kustomize or raw YAML:
+
+```bash
+kubectl delete -f <original-manifest-path>
+```
+
+### 4. Clean up the IngressClass
+
+```bash
+kubectl delete ingressclass nginx --ignore-not-found
+kubectl delete ingressclass webapprouting.kubernetes.azure.com --ignore-not-found
+```
+
+### 5. Remove orphaned LoadBalancer Services
+
+If the App Routing addon or your Helm install created `LoadBalancer` Services with public IPs, those Azure Public IPs may still exist:
+
+```bash
+az network public-ip list -g MC_<rg>_<cluster>_<region> -o table
+```
+
+Delete any tied to the removed Services. Be careful: AKS Automatic uses `MC_*` resource groups and other addons may also have IPs there.
+
+### 6. Lock against reinstall (Gatekeeper / Kyverno)
+
+Add a policy that rejects creation of any `Ingress` resource cluster-wide, forcing developers to use `HTTPRoute`:
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-legacy-ingress
+spec:
+  validationFailureAction: Enforce
+  rules:
+    - name: deny-ingress
+      match:
+        any:
+          - resources:
+              kinds: ["Ingress"]
+      validate:
+        message: "Use HTTPRoute (Gateway API) instead of Ingress. See docs/runbook/."
+        deny: {}
+```
+
+Apply:
+
+```bash
+kubectl apply -f cluster-policy/deny-legacy-ingress.yaml
+```
+
+### 7. Update internal docs and golden paths
+
+- Remove ingress-nginx samples from internal templates.
+- Update CI scaffolding (Backstage, etc.) to generate `HTTPRoute` not `Ingress`.
+- Archive the assessment.json from Phase 01 to your knowledge base.
+
+## Validation
+
+- [ ] `kubectl get ingress -A` returns `No resources found`.
+- [ ] `kubectl get ingressclass` does not include `nginx` or `webapprouting.kubernetes.azure.com`.
+- [ ] `az aks show -g <rg> -n <cluster> --query ingressProfile.webAppRouting.enabled` returns `false`.
+- [ ] No `LoadBalancer` Services remain that were owned by the legacy controller.
+- [ ] Kyverno or Gatekeeper policy is `Enforce` and rejects a test `Ingress` apply.
+
+## Rollback
+
+Re-enable App Routing:
+
+```bash
+az aks approuting enable -g <rg> -n <cluster>
+```
+
+Or reinstall ingress-nginx via Helm. **However**, after this phase your Ingress YAMLs no longer exist in the cluster. You would need to re-apply them from version control. Production traffic is on AGC, so the rollback path is to flip DNS back (Phase 07 rollback) **before** Phase 08, not after.
+
+## References
+
+- [App Routing addon disable](https://learn.microsoft.com/azure/aks/app-routing#enable-or-disable-the-app-routing-addon) (accessed 2026-04-22)
+- [Kyverno cluster policies](https://kyverno.io/docs/writing-policies/) (accessed 2026-04-22)

--- a/docs/runbook/09-rollback.md
+++ b/docs/runbook/09-rollback.md
@@ -1,0 +1,114 @@
+# Phase 09 — Rollback paths
+
+## Goal
+
+Document the reverse path at every phase so the operator knows the exact steps to abort.
+
+## Decision tree
+
+```text
+What went wrong?
+
+├─ Pre-cutover failure (Phases 01-06)
+│   └─ Rollback: see per-phase Rollback section. No production impact.
+│
+├─ Cutover causing user-visible errors (Phase 07)
+│   ├─ Pattern A (DNS flip)        -> reset CNAME to legacy
+│   └─ Pattern B (weighted ramp)   -> set AGC endpoint weight to 0
+│
+└─ Post-decommission failure (Phase 08+)
+    └─ Operationally hard. See "Worst case" below.
+```
+
+## Phase 07 rollback (production cutover)
+
+### Option A: DNS flip back to ingress-nginx
+
+```bash
+LEGACY_LB_FQDN=$(az network public-ip show \
+  -g MC_<rg>_<cluster>_<region> \
+  -n kubernetes-<svc-uid> \
+  --query dnsSettings.fqdn -o tsv)
+
+az network dns record-set cname set-record \
+  --resource-group <dns-rg> \
+  --zone-name contoso.com \
+  --record-set-name app \
+  --cname "$LEGACY_LB_FQDN"
+```
+
+If you used the helper cmdlet for cutover, capture its rollback file:
+
+```powershell
+# Invoke-TrafficCutover writes a rollback plan to ./cutover-rollback-<timestamp>.json
+Get-ChildItem ./cutover-rollback-*.json | Select-Object -Last 1
+```
+
+The JSON contains the prior CNAME and the exact `az network dns` command to reverse it.
+
+### Option B: Weighted ramp rollback
+
+```bash
+az network traffic-manager endpoint update \
+  --profile-name app-tm --resource-group <rg> \
+  --name agc --type externalEndpoints --weight 0
+
+az network traffic-manager endpoint update \
+  --profile-name app-tm --resource-group <rg> \
+  --name nginx --type externalEndpoints --weight 100
+```
+
+### Validation after rollback
+
+```bash
+dig +short app.contoso.com
+curl -sS https://app.contoso.com/healthz
+```
+
+Confirm `nginx_ingress_controller_requests` rate climbs back and AGC `RequestCount` falls.
+
+## Phase 08 rollback (post-decommission, worst case)
+
+If you discover a critical issue **after** uninstalling ingress-nginx and DNS is on AGC:
+
+1. **Stay on AGC.** Reverting to ingress-nginx is slower than fixing forward in almost every case.
+2. Reapply the original Ingress YAMLs to a temporary namespace if you need to inspect annotation behaviour.
+3. Reinstall ingress-nginx as a Helm release in `ingress-nginx` namespace **without** an `IngressClass` set as default. Apply original Ingress YAMLs with explicit `ingressClassName: nginx`.
+4. Re-enable the previous `LoadBalancer` Service.
+5. Switch DNS back per Phase 07 rollback.
+
+This path takes 30-60 minutes. The fix-forward path is almost always shorter.
+
+## Common pitfalls and recovery
+
+| Symptom | Cause | Recovery |
+|---|---|---|
+| AGC frontend returns 502 for all requests | NetworkPolicy missing for AGC subnet | Re-apply `allow-from-agc` policies |
+| AGC frontend returns 503 intermittently | HTTPRoute backendRef Service has no endpoints | `kubectl get endpoints -n <ns> <svc>`, fix Pod readiness |
+| TLS handshake fails | `certificateRefs` Secret is in different namespace | Move Secret or use `ReferenceGrant` |
+| Controller log: `AADSTS70021` | Federated credential subject mismatch | Verify exact `system:serviceaccount:<ns>:<sa>` value |
+| Gateway stuck `Programmed: False` | AGC association subnet too small | Resize subnet or pick a larger one |
+| Cutover spike in 5xx | Connection draining on legacy LB cut active streams | Lower DNS TTL further, retry next window |
+
+## Version capture
+
+Before any rollback, snapshot the current state for postmortem:
+
+```bash
+mkdir -p rollback-evidence/$(date +%Y%m%d-%H%M%S)
+cd rollback-evidence/*
+
+kubectl get gateway,httproute,backendtrafficpolicy,backendtlspolicy -A -o yaml > gateway-state.yaml
+kubectl get pods -n azure-alb-system -o yaml > controller-state.yaml
+kubectl logs -n azure-alb-system deployment/alb-controller --tail=2000 > controller.log
+az network alb show -g <rg> -n <agc> > agc-show.json
+az network alb frontend list -g <rg> --alb-name <agc> > agc-frontends.json
+```
+
+Attach to incident.
+
+## References
+
+- [Helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) (accessed 2026-04-22)
+- [Azure DNS CNAME](https://learn.microsoft.com/azure/dns/dns-getstarted-cli#create-a-dns-record-set-and-records) (accessed 2026-04-22)
+- [Gateway API ReferenceGrant](https://gateway-api.sigs.k8s.io/api-types/referencegrant/) (accessed 2026-04-22)


### PR DESCRIPTION
## Summary

Adds a complete 10-phase migration runbook from preflight through rollback, plus a `docs/index.md` navigation hub.

Each phase file follows the same structure: **Goal**, **Prerequisites**, **Steps**, **Validation**, **Rollback**, **References**. Every claim about retirement dates and product behaviour links to MS Docs or upstream GitHub with accessed date 2026-04-22.

## Phases

| Phase | Outcome |
|---|---|
| 00 | Mental model shift, preflight checklist |
| 01 | Inventory + annotation classification (uses `Get-MigrationAssessment`) |
| 02 | AGC base infra (TF or Bicep) + parity validation |
| 03 | Workload Identity federation for ALB controller |
| 04 | `Convert-IngressToGateway` translation + manual patches |
| 05 | NetworkPolicies, DNS strategy, TLS via cert-manager or Key Vault |
| 06 | Shadow traffic + observability parity gate |
| 07 | DNS flip or weighted ramp cutover |
| 08 | Decommission ingress-nginx and App Routing addon, Kyverno lock |
| 09 | Rollback decision tree + per-phase recovery |

## Validation gates passed

- `terraform fmt -check -recursive` ✅
- `pwsh scripts/validate-iac-parity.ps1` ✅ (no IaC files changed)
- Manual review against ADR-001/002/003 ✅

Closes the docs portion of the toolkit completion task.
