### PR TITLE
security: add workflow permissions (wave-2)

### DIFF
--- a/.github/workflows/iac-parity.yml
+++ b/.github/workflows/iac-parity.yml
@@ -18,6 +18,9 @@ on:
       - 'scripts/validate-iac-parity.ps1'
       - '.github/workflows/iac-parity.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate-agc-module:
     name: Validate AGC Module Parity


### PR DESCRIPTION
## Overview
Adds explicit workflow permissions block to comply with security audit wave-2 recommendation (MEDIUM severity, 30d SLA).

## Changes
- Added top-level permissions block: contents: read
- Scope: applies to validate-agc-module job

## Rationale
GitHub Actions workflows should follow principle of least privilege. This workflow only needs read access to repository contents for checkout and validation steps.

## Audit Context
- Squad: The Wire (security audit wave-2)
- Finding: Missing explicit permissions declaration
- SLA: 30 days (MEDIUM severity)
- Workflow: .github/workflows/iac-parity.yml
