### PR TITLE
ci: add workflow to enforce required status checks on main

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,69 @@
+name: branch-protection
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  administration: write
+
+jobs:
+  update-required-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update required status checks for main
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = 'main';
+
+            // Required contexts for main branch
+            const requiredContexts = [
+              'scan',
+              'analyze (actions)',
+              'review',
+              'terraform',
+              'bicep',
+              'manifests',
+              'Validate AGC Module Parity'
+            ];
+
+            // Fetch existing protection to merge with current settings
+            let existingContexts = [];
+            try {
+              const { data: protection } = await github.rest.repos.getBranchProtection({
+                owner,
+                repo,
+                branch
+              });
+              if (protection.required_status_checks && protection.required_status_checks.contexts) {
+                existingContexts = protection.required_status_checks.contexts;
+              }
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              // Branch protection doesn't exist yet, that's fine
+            }
+
+            // Merge and dedupe
+            const mergedContexts = [...new Set([...existingContexts, ...requiredContexts])].sort();
+
+            // Update required status checks
+            await github.rest.repos.updateBranchProtection({
+              owner,
+              repo,
+              branch,
+              required_status_checks: {
+                strict: false,
+                contexts: mergedContexts
+              },
+              enforce_admins: null,
+              required_pull_request_reviews: null,
+              restrictions: null
+            });
+
+            console.log(`Updated required status checks for ${branch}:`);
+            console.log(mergedContexts.join('\n'));


### PR DESCRIPTION
Adds manual workflow to configure required status checks. Replaces #29. Corrects case mismatch (analyze vs Analyze) and removes validate/ prefix from job IDs per Lead review.