### PR TITLE
docs: publish migration plan schema v1 contract entry point

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -100,7 +100,7 @@ The following components are developed as part of this repository and licensed u
 
 ## Migration plan schema (first-party)
 
-- **Source:** `schema/migration-plan.v1.json` (planned)
+- **Source:** `schema/migration-plan.v1.json` (compatibility entry point), `schemas/migration-plan/v1/schema.json` (canonical schema)
 - **Copyright:** Copyright (c) 2026 martinopedal
 - **License:** MIT License (see [LICENSE](LICENSE))
 - **Usage:** Versioned cross-repo contract consumed by `mcp-server-azure-architect`'s `ingress-migration-plan` skill.

--- a/schema/migration-plan.v1.json
+++ b/schema/migration-plan.v1.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/martinopedal/aks-automatic-ingress-migration/main/schema/migration-plan.v1.json",
+  "title": "Migration Plan Schema v1 Compatibility Entry Point",
+  "description": "Compatibility entry point for cross-repo consumers that resolve schema/migration-plan.v1.json.",
+  "$ref": "../schemas/migration-plan/v1/schema.json"
+}

--- a/schemas/migration-plan/v1/examples/valid.minimal.json
+++ b/schemas/migration-plan/v1/examples/valid.minimal.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "v1",
+  "metadata": {
+    "name": "minimal-migration-plan",
+    "description": "Minimal valid migration plan contract example.",
+    "createdAt": "2026-04-22T00:00:00Z"
+  },
+  "source": {
+    "cluster": {
+      "name": "aks-prod-01",
+      "kubernetesVersion": "1.29.4"
+    },
+    "ingressController": {
+      "type": "ingress-nginx",
+      "version": "4.10.0"
+    }
+  },
+  "target": {
+    "agc": {
+      "name": "agc-prod-01",
+      "resourceGroup": "rg-network-prod"
+    },
+    "gatewayApi": {
+      "version": "v1"
+    }
+  },
+  "steps": [
+    {
+      "id": "step-01-prereq",
+      "name": "Run prerequisite checks",
+      "phase": "prereq",
+      "actions": [
+        {
+          "type": "manual",
+          "instructions": "Confirm migration window and rollback owner."
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/migration-plan/v1/examples/valid.minimal.yaml
+++ b/schemas/migration-plan/v1/examples/valid.minimal.yaml
@@ -1,0 +1,25 @@
+schemaVersion: v1
+metadata:
+  name: minimal-migration-plan
+  description: Minimal valid migration plan contract example.
+  createdAt: "2026-04-22T00:00:00Z"
+source:
+  cluster:
+    name: aks-prod-01
+    kubernetesVersion: 1.29.4
+  ingressController:
+    type: ingress-nginx
+    version: 4.10.0
+target:
+  agc:
+    name: agc-prod-01
+    resourceGroup: rg-network-prod
+  gatewayApi:
+    version: v1
+steps:
+  - id: step-01-prereq
+    name: Run prerequisite checks
+    phase: prereq
+    actions:
+      - type: manual
+        instructions: Confirm migration window and rollback owner.

--- a/schemas/migration-plan/v1/schema.json
+++ b/schemas/migration-plan/v1/schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/martinopedal/aks-automatic-ingress-migration/main/schemas/migration-plan/v1/schema.json",
   "title": "Migration Plan Schema v1",
-  "description": "Versioned schema for AKS Automatic ingress-nginx to Gateway API + AGC migration plans. Consumed by mcp-server-azure-architect ingress-migration-plan skill and other cross-repo consumers. Breaking changes increment the schema version (v1 to v2).",
+  "description": "Versioned schema for AKS Automatic ingress-nginx to Gateway API + AGC migration plans. Consumed by mcp-server-azure-architect ingress-migration-plan skill and other cross-repo consumers. Breaking changes increment the schema version (v1 to v2). Per ADR-001, this repo orchestrates upstream tools and provides ALZ Corp IaC. This schema is the contract for orchestration, not re-translation.",
   "type": "object",
   "required": ["schemaVersion", "metadata", "source", "target", "steps"],
   "additionalProperties": false,


### PR DESCRIPTION
## Summary

This PR addresses the critical gap identified in closed #37: the canonical schema file was missing. The entry point schema/migration-plan.v1.json referenced schemas/migration-plan/v1/schema.json, but that file did not exist in the closed PR.

## What was added

1. **Entry point**: schema/migration-plan.v1.json - compatibility entry point for cross-repo consumers
2. **Examples**: 
   - schemas/migration-plan/v1/examples/valid.minimal.json
   - schemas/migration-plan/v1/examples/valid.minimal.yaml
3. **Schema update**: Enhanced the canonical schema description to explicitly reference ADR-001
4. **Documentation**: Updated THIRD_PARTY_NOTICES.md to reflect actual file locations

## ADR-001 alignment

Per [ADR-001: Positioning vs Upstream Tools](docs/adr/ADR-001-positioning-vs-upstream-tools.md), this repository orchestrates upstream tools and does not re-translate. The migration plan schema is the contract consumed by mcp-server-azure-architect's ingress-migration-plan skill. The schema description now explicitly states this positioning.

## Validation

- Manual PowerShell validation confirmed all required fields are present in the example
- No GUIDs or sensitive data detected in examples
- Entry point \\\ correctly points to canonical schema

## Related

Closes #37 (originally closed by coordinator due to missing canonical schema)