### PR TITLE
docs: voice and hygiene sweep per project voice profile

### DIFF
--- a/.squad/agents/sage/history.md
+++ b/.squad/agents/sage/history.md
@@ -59,3 +59,34 @@ Activity log for Sage (Research and Runbook Author).
 **Quality gate before merge:** (1) Opening sentence stops scroll, (2) at least one specific technical detail, (3) concrete CTA, (4) no em dashes/banned phrases, (5) no AI structural patterns, (6) all date/default claims link to primary sources.
 
 **Next session:** Sage sweeps listed files, applies voice profile, commits with `chore(docs):` prefix.
+
+### 2026-05-12: Voice sweep executed (PR #49)
+
+Branch `chore/docs-voice-sweep`, 16 files modified, opened as PR #49.
+
+What the corpus actually looked like before the sweep, in order of frequency:
+
+1. The dominant violation was H1 em dashes in runbook phase headings. Every single phase file (`00-overview.md` through `09-rollback.md`, 10 files) used the pattern `# Phase NN — Title`. Replaced with `# Phase NN, title`. If a future contributor adds an `11-` or `12-` phase doc, they will almost certainly reach for the em dash by reflex. Worth a lint rule.
+
+2. The second most prevalent pattern was bold-heading-colon tricolon filler at the END of READMEs, packaged as `## Style` or `## Design Philosophy`. Two of three module READMEs ended with this pattern (`scripts/migration/README.md`, `presentation/README.md`). The hello-world README was clean. The pattern reads as a sign-off ritual, like a corporate values poster nailed to the bottom of the doc. Both were rewritten as prose paragraphs that name concrete cmdlets, failure modes, and references.
+
+3. Banned phrases were rare. Only two prose instances across 22 files (`leverage` in ADR-001, `accelerate` in ADR-003). All other matches for `accelerat` were inside the Microsoft product slug `landing-zone-accelerator` in URLs and link titles, which cannot be changed. The phrase list is doing more work than the count suggests, because authors self-censor against it once they know it exists.
+
+4. Title-case headings were the slow-burn issue: `Alternatives Considered`, `Refresh Procedure`, `What Parity Means`. Eight headings flipped to sentence case across the three ADRs and the compatibility matrix.
+
+5. Spelling drift (`Cost-optimised`, British) appeared once in a topology table in Phase 04. Worth a future pass with a configured spell list, but not urgent.
+
+What did NOT need rewriting:
+
+- Numbered ADR contract enumerations (e.g. ADR-002 `1. **Names.** Output keys match...`) read as semantic data, not decorative tricolon.
+- The `→` arrow character in `Ingress → HTTPRoute` and similar is not a dash, not an emoji, and not a bullet ornament. Voice profile is silent on it. Left in place. Reconsider if it spreads.
+- Words like `simplest`, `easy rollback`, `Smallest blast radius` in tables are pragmatic operational descriptors, not AI marketing tells.
+
+Things to watch for in future sweeps:
+
+- New phase docs reaching for em dashes in H1.
+- New READMEs ending with a `## Style` or `## Philosophy` tricolon coda.
+- Any spread of the `→` arrow into prose (currently only in titles and conversion arrows).
+- Any new `**Bold**: filler.` patterns introduced by Atlas, Iris, or Sentinel in their own docs as the contributor base grows.
+
+The corpus was in better shape than expected. Two phrase rewrites, one British spelling, eight heading flips, two README codas, and ten H1 em dashes. The voice profile is mostly preventing future drift, not cleaning up existing damage.

--- a/docs/adr/ADR-001-positioning-vs-upstream-tools.md
+++ b/docs/adr/ADR-001-positioning-vs-upstream-tools.md
@@ -43,7 +43,7 @@ We remain focused on the orchestration layer that upstream tools do not cover. I
 ### Positive
 
 - **Clear scope.** No confusion about our role. We orchestrate, not translate.
-- **No duplicate effort.** We leverage upstream translation logic (`ingress2gateway` v1.0 GA is stable and feature-complete).
+- **No duplicate effort.** We consume upstream translation logic (`ingress2gateway` v1.0 GA is stable and feature-complete).
 - **Tight integration.** We can wrap `ingress2gateway` in PowerShell or Terraform provisioner blocks and feed output directly to `kubectl apply` or Helm workflows.
 - **Maintenance reduced.** Translation logic is owned by Kubernetes SIG Network. We only maintain runbook, IaC, and examples.
 
@@ -56,7 +56,7 @@ We remain focused on the orchestration layer that upstream tools do not cover. I
 
 - **Two upstream tools exist.** Users may ask which one to use. Answer: `ingress2gateway` for Kubernetes-native workflows, Azure's migration utility for AGIC-to-AGC migrations. Our runbook supports both, favoring `ingress2gateway` for its vendor-neutral design.
 
-## Alternatives Considered
+## Alternatives considered
 
 ### Build a competing translator
 

--- a/docs/adr/ADR-002-bicep-terraform-parity-contract.md
+++ b/docs/adr/ADR-002-bicep-terraform-parity-contract.md
@@ -18,7 +18,7 @@ This repository has no value if customers must maintain parallel implementations
 
 **We enforce output schema equivalence, not source equivalence.**
 
-### What Parity Means
+### What parity means
 
 Parity is defined at the module output boundary. For every Terraform module under `terraform/`, there must exist a Bicep module under `bicep/` with the same logical scope (e.g., `terraform/modules/agc` and `bicep/modules/agc`). Both modules must expose outputs with identical:
 
@@ -34,7 +34,7 @@ Source equivalence is NOT required. Bicep and Terraform have different idioms:
 
 Each stack should follow its language's best practices. We test outputs, not source.
 
-### What We Test
+### What we test
 
 Every module directory under `terraform/` and `bicep/` must include an `outputs.schema.json` file that declares the expected output keys, types, and descriptions. Example:
 
@@ -67,7 +67,7 @@ CI validates:
 
 We do NOT execute `terraform apply` or `az deployment group create` in CI for parity tests. We rely on `terraform output -json` against a `.tfstate` fixture and `az deployment group what-if --result-format FullResourcePayloads` or pre-validated output manifests. For modules without live deployments, contributors manually validate and document outputs in `outputs.schema.json`.
 
-### The CI Gate
+### The CI gate
 
 A GitHub Actions workflow `.github/workflows/parity-check.yml` runs on every PR that touches `terraform/`, `bicep/`, or `outputs.schema.json` files. Steps:
 
@@ -99,7 +99,7 @@ This workflow runs before any manual review. PRs cannot merge without a passing 
 - **Not every file requires parity.** Terraform-specific tooling (e.g., `terraform fmt`, `tflint` configs) and Bicep-specific tooling (e.g., `bicepconfig.json`) live in their respective directories without equivalents. Only modules with outputs are subject to parity.
 - **Escape hatch exists.** If a feature is only available in one stack, we document the gap in `.squad/decisions.md` with a "deferred parity" decision and a target date for resolution. This unblocks time-sensitive features while preserving the long-term contract.
 
-## Alternatives Considered
+## Alternatives considered
 
 ### Source-level parity
 

--- a/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
+++ b/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
@@ -68,9 +68,9 @@ This ADR does not mandate creating the full content of `docs/runbook/00-prereq-a
 
 ### Neutral
 
-- **Creates a forcing function for GA.** If Microsoft sees customers blocked by the prerequisite check, it may accelerate private cluster GA. Conversely, if preview is working well, customers may accept the risk. Either outcome is information.
+- **Creates a forcing function for GA.** If Microsoft sees customers blocked by the prerequisite check, that pressure may pull private cluster GA forward. If preview is working well, customers may accept the risk. Either outcome is information.
 
-## Alternatives Considered
+## Alternatives considered
 
 ### Hide the limitation behind a warning
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,4 +1,4 @@
-# Compatibility Matrix
+# Compatibility matrix
 
 **Owner:** Atlas (`squad:atlas`)  
 **Review cadence:** Quarterly  
@@ -22,7 +22,7 @@ This matrix tracks the validated version set for AKS Automatic migration work in
 |---|---|---|---|---|---|
 | 2026-Q2 | Track from AKS supported versions and release tracker | Track from Microsoft ALB Controller release notes | v1 CRD track, verify against gateway-api releases and ALB Controller notes | v1.0.0 baseline | Initial matrix baseline for this repo |
 
-## Refresh Procedure
+## Refresh procedure
 
 1. Check all sources in this file.
 2. Update the matrix row for the current quarter.

--- a/docs/runbook/00-overview.md
+++ b/docs/runbook/00-overview.md
@@ -1,4 +1,4 @@
-# Phase 00 — Overview and preflight
+# Phase 00, overview and preflight
 
 ## Goal
 

--- a/docs/runbook/01-assess-current-ingress.md
+++ b/docs/runbook/01-assess-current-ingress.md
@@ -1,4 +1,4 @@
-# Phase 01 — Assess current ingress estate
+# Phase 01, assess current ingress estate
 
 ## Goal
 

--- a/docs/runbook/02-provision-agc-base.md
+++ b/docs/runbook/02-provision-agc-base.md
@@ -1,4 +1,4 @@
-# Phase 02 — Provision AGC base infrastructure
+# Phase 02, provision AGC base infrastructure
 
 ## Goal
 

--- a/docs/runbook/03-identity-wiring.md
+++ b/docs/runbook/03-identity-wiring.md
@@ -1,4 +1,4 @@
-# Phase 03 — Identity wiring
+# Phase 03, identity wiring
 
 ## Goal
 

--- a/docs/runbook/04-translate-manifests.md
+++ b/docs/runbook/04-translate-manifests.md
@@ -1,4 +1,4 @@
-# Phase 04 — Translate Ingress manifests to Gateway + HTTPRoute
+# Phase 04, translate Ingress manifests to Gateway and HTTPRoute
 
 ## Goal
 
@@ -46,7 +46,7 @@ Decide before Phase 06 which topology you want. AGC supports both:
 
 | Topology | When to use |
 |---|---|
-| **Shared Gateway** per cluster (one `Gateway` in a platform namespace, app teams attach `HTTPRoute` via `parentRefs`) | Cost-optimised, central frontend cert mgmt, ALZ Corp default |
+| **Shared Gateway** per cluster (one `Gateway` in a platform namespace, app teams attach `HTTPRoute` via `parentRefs`) | Lowest cost, central frontend cert management, ALZ Corp default |
 | **Gateway per namespace** | Strong tenant isolation, multi-tenant clusters with hard boundaries |
 
 For ALZ Corp, prefer shared. The hello-world sample uses shared.

--- a/docs/runbook/05-network-and-dns.md
+++ b/docs/runbook/05-network-and-dns.md
@@ -1,4 +1,4 @@
-# Phase 05 — Network policies, DNS, and certs
+# Phase 05, network policies, DNS, and certs
 
 ## Goal
 

--- a/docs/runbook/06-shadow-traffic.md
+++ b/docs/runbook/06-shadow-traffic.md
@@ -1,4 +1,4 @@
-# Phase 06 — Shadow traffic and observation
+# Phase 06, shadow traffic and observation
 
 ## Goal
 

--- a/docs/runbook/07-cutover.md
+++ b/docs/runbook/07-cutover.md
@@ -1,4 +1,4 @@
-# Phase 07 — Production cutover
+# Phase 07, production cutover
 
 ## Goal
 

--- a/docs/runbook/08-decommission.md
+++ b/docs/runbook/08-decommission.md
@@ -1,4 +1,4 @@
-# Phase 08 — Decommission ingress-nginx and the App Routing addon
+# Phase 08, decommission ingress-nginx and the App Routing addon
 
 ## Goal
 

--- a/docs/runbook/09-rollback.md
+++ b/docs/runbook/09-rollback.md
@@ -1,4 +1,4 @@
-# Phase 09 — Rollback paths
+# Phase 09, rollback paths
 
 ## Goal
 

--- a/presentation/README.md
+++ b/presentation/README.md
@@ -74,8 +74,6 @@ Citations are inline with `<p class="citation">` elements. All retirement dates 
 
 ## Style
 
-- **No em dashes.** Use periods or commas.
-- **Citation rigor.** Every claim about retirement dates, default behavior, or preview status includes a source URL.
-- **Concise speaker notes.** Direct prose, no marketing voice.
+No em dashes. Use commas or periods. Every claim about retirement dates, default behavior, or preview status links to MS Learn or upstream GitHub. Speaker notes are direct prose, not marketing copy.
 
-Follows project conventions from `.github/copilot-instructions.md` and `.squad/agents/sage/charter.md`.
+Follows project conventions in `.github/copilot-instructions.md` and `.squad/skills/voice-profile/SKILL.md`.

--- a/scripts/migration/README.md
+++ b/scripts/migration/README.md
@@ -74,13 +74,13 @@ Exclude integration tests (require ingress2gateway binary):
 Invoke-Pester ./scripts/migration/tests -ExcludeTag integration
 ```
 
-## Design Philosophy
+## Design philosophy
 
-- **Read-only first:** All tools default to dry-run or preview mode
-- **Human-driven cutover:** Traffic shifts stay manual for safety
-- **Clear boundaries:** Each script has one responsibility
+All cmdlets default to dry-run or preview. `Convert-IngressToGateway` requires `-WhatIf:$false` or `-Force` to actually write files. `Get-MigrationAssessment` is read-only by design. `Invoke-TrafficCutover` produces a Markdown checklist; the actual DNS or Traffic Manager change stays a human decision because cutover failure modes (cache TTL, partial propagation, routing loops) need eyes on dashboards, not a script.
 
-See `.squad/decisions/inbox/forge-migration-scripts-philosophy.md` for details.
+Each script does one thing. Translation, inventory, and cutover are separate cmdlets so a failure in one does not contaminate the others.
+
+See `.squad/decisions/inbox/forge-migration-scripts-philosophy.md` for the full rationale.
 
 ## Links
 


### PR DESCRIPTION
## Summary

Sweep all repo prose for voice, emoji, em-dash, and AI-language hygiene per `.squad/skills/voice-profile/SKILL.md` (decision 9 in `.squad/decisions.md`). 22 markdown files reviewed across docs, ADRs, runbook, and the three READMEs (root, scripts/migration, examples/hello-world, presentation). 16 files modified.

## Changes by category

### Em dash removal (10 files)
All runbook H1 headings replaced `Phase NN — Title` with `Phase NN, title`. Files: `00-overview.md` through `09-rollback.md`.

### Banned phrase rewrites
- ADR-001 line 46: `leverage` → `consume`.
- ADR-003 line 71: `it may accelerate private cluster GA` → `that pressure may pull private cluster GA forward`.
- Phase 04 topology table: `Cost-optimised` → `Lowest cost`, `cert mgmt` → `cert management`.

### Sentence-case headings
- `Alternatives Considered` → `Alternatives considered` (ADR-001, ADR-002, ADR-003).
- `What Parity Means`, `What We Test`, `The CI Gate` → sentence case (ADR-002).
- `Compatibility Matrix`, `Refresh Procedure` → sentence case (compatibility-matrix.md).

### Tricolon bold-heading-colon list endings rewritten as prose
- `scripts/migration/README.md` `Design Philosophy`: replaced three bold-colon bullets (`Read-only first:`, `Human-driven cutover:`, `Clear boundaries:`) with two paragraphs naming each cmdlet and the concrete cutover failure modes (cache TTL, partial propagation, routing loops) that justify keeping it human-driven.
- `presentation/README.md` `Style`: replaced three bold-colon bullets with one short paragraph stating the no-em-dash, citation-link, and direct-prose rules.

## Preserved

All citations dated and linked. All command examples and code blocks intact. Allowed status emoji (`✓` U+2713, `✗` U+2717) untouched. The only `accelerat` matches that survive are in the Microsoft product slug `landing-zone-accelerator` in URLs and link titles, which cannot be changed.

## Verification

- `rg -n '[—–]'` against the 22 files: 0 matches.
- Banned-phrase sweep against the voice profile list: 0 matches outside the Microsoft product slug above.
- Emoji codepoint scan (`[\u2600-\u27BF]` plus surrogate range): only `✓` `✗` survive, and only inside table or checklist context.

## Out of scope

Light bold-list patterns in numbered ADR contracts (e.g. ADR-002 numbered `Names`, `Value semantics`, `Types` items) and date-prefixed bullet lists in the root README left in place. These are data-driven enumerations, not the decorative tricolon filler the voice profile rejects.

## Follow-ups

If reviewers want a stricter pass, the next sweep candidates are:
- The runbook `Goal` one-liners read as generic intros. Could be tightened to a concrete observation per phase.
- The root README's `Why this exists` opens with `Two timelines collide for AKS Automatic users:`, which is acceptable but could be hardened with a single concrete user moment.

Closes nothing yet, this is the prose half of decision 9.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>