### PR TITLE
docs(adr): correct ADR-001/003 citations with verified MS Learn sources

### DIFF
--- a/docs/adr/ADR-001-positioning-vs-upstream-tools.md
+++ b/docs/adr/ADR-001-positioning-vs-upstream-tools.md
@@ -8,7 +8,7 @@
 
 ## Context
 
-AKS Automatic users face a November 2026 deadline when Microsoft's App Routing addon with ingress-nginx will move to critical-only support, per [AKS ingress-nginx retirement guidance](https://learn.microsoft.com/en-us/azure/aks/http-application-routing-migrate). The migration path to Application Gateway for Containers (AGC) with Gateway API is well-defined in Microsoft documentation, but two upstream tools already exist in this space:
+AKS Automatic users face a November 2026 deadline when Microsoft's App Routing add-on (managed NGINX) will stop receiving Azure support, per the caution callout in [App routing Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api): "the managed NGINX add-on... will stop receiving Azure support from Azure after November 2026." The community ingress-nginx project itself enters maintenance mode in March 2026, per [Ingress NGINX retirement](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/). The migration path to Application Gateway for Containers (AGC) with Gateway API is well-defined in Microsoft documentation, but two upstream tools already exist in this space:
 
 1. **[Azure/Application-Gateway-for-Containers-Migration-Utility](https://github.com/Azure/Application-Gateway-for-Containers-Migration-Utility)**  
    - Microsoft-maintained CLI tool for translating AGIC or NGINX Ingress resources to Gateway API resources compatible with AGC.
@@ -72,8 +72,9 @@ We could rely on upstream tools and Microsoft documentation alone. Rejected beca
 
 ## References
 
-- [Application Gateway for Containers overview](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/overview)
-- [AKS App Routing addon retirement timeline](https://learn.microsoft.com/en-us/azure/aks/http-application-routing-migrate)
+- [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview)
+- [App routing Gateway API (preview), with November 2026 caution callout](https://learn.microsoft.com/azure/aks/app-routing-gateway-api)
+- [Ingress NGINX retirement, March 2026](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/)
 - [Azure/Application-Gateway-for-Containers-Migration-Utility](https://github.com/Azure/Application-Gateway-for-Containers-Migration-Utility)
 - [kubernetes-sigs/ingress2gateway](https://github.com/kubernetes-sigs/ingress2gateway)
 - [ingress2gateway v1.0.0 release](https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.0.0)

--- a/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
+++ b/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
@@ -10,18 +10,13 @@
 
 ADR-001 established ALZ Corp as the default positioning for this repository. ALZ Corp means hub-spoke networks with central Azure Firewall egress, no public IPs on AKS nodes, and private cluster API servers. This is the Microsoft-recommended architecture for enterprise AKS deployments, per [Azure Landing Zone guidance](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator).
 
-Application Gateway for Containers (AGC) reached General Availability (GA) for public AKS clusters in November 2025, including Web Application Firewall (WAF) support. However, as of April 22, 2026, AGC support for private AKS clusters is still in preview with no official GA date published by Microsoft.
+Application Gateway for Containers (AGC) is generally available, with feature support including Web Application Firewall (WAF), per [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) (accessed 2026-05-13). However, deployment paths supported on AKS Automatic and on AKS clusters with private API servers warrant explicit verification before adoption.
 
-This creates a hard prerequisite gap. Our default scenario (private cluster) requires a preview feature. Production-supported deployments typically cannot rely on preview features. While customers can use AGC with private clusters today, Microsoft does not guarantee backward-compatibility, SLA, or long-term support for preview functionality.
+Per the [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) (accessed 2026-05-13): "when using the Application Gateway for Containers ALB Controller AKS add-on, the ALB Controller can be provisioned into AKS Automatic clusters. Helm deployments of the ALB Controller aren't supported with AKS Automatic." The AKS add-on path itself requires preview feature flags `ManagedGatewayAPIPreview` and `ApplicationLoadBalancerPreview`, per [Quickstart: Deploy AGC ALB Controller AKS add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon). For AKS Automatic specifically, this means the only supported AGC controller path is in preview as of the verified date.
 
-Research from Azure engineering blogs and migration guides published in early 2026 suggests GA for private cluster support is expected mid-2026, but this is not officially confirmed by Microsoft documentation. The [Azure Updates page](https://azure.microsoft.com/en-us/updates/) does not list a specific GA timeline as of this date. The [AGC overview page](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/overview) accessed April 22, 2026, confirms AGC is GA and lists 23 supported regions but does not distinguish public versus private cluster support status.
+For AGC private cluster scenarios on standard AKS (not Automatic), Microsoft documentation does not explicitly mark private cluster support as preview on the AGC overview or FAQ pages as of 2026-05-13. The previously circulated `private-cluster-support` documentation page is no longer published. Customers running ALZ Corp private clusters should verify status with their Azure account team before depending on it, and should treat it as a hard prerequisite check until Microsoft publishes a definitive GA statement.
 
-Additional considerations:
-- Kubenet networking is not supported by AGC. Only Azure CNI (static or dynamic IP) is compatible.
-- Some regions may support AGC generally but have different timelines or limitations for private cluster scenarios.
-- Preview features require explicit Azure subscription preview registration in some cases.
-
-The November 2026 deadline for ingress-nginx retirement means customers need clarity now, even if the full AGC private cluster GA occurs mid-2026.
+This creates a hard prerequisite gap. Our default scenario (AKS Automatic with private cluster API) sits on at least one preview feature (the AKS add-on path), and possibly more depending on Microsoft's evolving documentation of private cluster support. Production-supported deployments typically cannot rely on preview features without accepting the [Azure preview supplemental terms](https://azure.microsoft.com/support/legal/preview-supplemental-terms/) (no SLA, no production warranty, breaking changes possible).
 
 ## Decision
 
@@ -36,11 +31,7 @@ Concrete deliverables:
    - Document the workaround path: customers can opt for a public cluster (not ALZ Corp default), use a hybrid approach (public frontend, private backend), or engage Azure support for preview registration and guidance.
    - Link to the per-region matrix for availability nuances.
 
-2. **Per-region availability matrix:** Create `docs/agc-region-matrix.md` with:
-   - A table listing the 23 AGC-supported regions (as of April 22, 2026: Australia East, Brazil South, Canada Central, Central India, Central US, East Asia, East US, East US 2, France Central, Germany West Central, Korea Central, North Central US, North Europe, Norway East, South Central US, Southeast Asia, Switzerland North, UAE North, UK South, West US, West US 2, West US 3, West Europe).
-   - A column noting private cluster support status per region (initially marked "Preview, no GA date" for all).
-   - A "Last Verified" date at the top of the file.
-   - A note that this matrix is reviewed quarterly by Sage and updated when Microsoft publishes GA announcements.
+2. **Per-region availability matrix:** `docs/agc-region-matrix.md` is the canonical region list for the toolkit, sourced from the AGC overview's [Supported regions](https://learn.microsoft.com/azure/application-gateway/for-containers/overview#supported-regions) section. This ADR does not embed a duplicate region list; readers should consult that file for the verified list.
 
 3. **Quarterly review cadence:** Sage owns a recurring task to check the [Azure Updates page](https://azure.microsoft.com/en-us/updates/) and AGC documentation quarterly. If GA is announced, `docs/runbook/00-prereq-agc-availability.md` and `docs/agc-region-matrix.md` are updated, and the runbook prerequisite check is relaxed or removed.
 
@@ -82,7 +73,7 @@ We could abandon ADR-001's ALZ Corp wedge and only document public cluster migra
 
 ### Wait for GA before launching the runbook
 
-We could delay all runbook publication until AGC private cluster support is GA. Rejected because the November 2026 ingress-nginx deadline does not permit waiting. Customers need migration guidance now. If GA occurs mid-2026, we have months to refine the runbook post-GA.
+We could delay all runbook publication until AGC private cluster support is unambiguously GA in Microsoft documentation. Rejected because the November 2026 cutoff for App Routing's Azure support (per the [Gateway API caution callout](https://learn.microsoft.com/azure/aks/app-routing-gateway-api)) and the March 2026 community ingress-nginx maintenance end (per [Ingress NGINX retirement](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/)) do not permit waiting. Customers need migration guidance now.
 
 ### Treat preview as "good enough" and document without a gate
 
@@ -90,12 +81,15 @@ We could document the preview status but not call it a hard prerequisite block. 
 
 ## References
 
-- [Application Gateway for Containers overview](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/overview) (accessed 2026-04-22)
-- [Azure Updates](https://azure.microsoft.com/en-us/updates/) (accessed 2026-04-22)
-- [AKS App Routing addon retirement timeline](https://learn.microsoft.com/en-us/azure/aks/http-application-routing-migrate) (accessed 2026-04-22)
-- [Azure Landing Zone guidance for AKS](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator) (accessed 2026-04-22)
-- [Azure support request process](https://learn.microsoft.com/en-us/azure/azure-portal/supportability/how-to-create-azure-support-request)
-- [Azure preview feature registration](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/preview-features)
+- [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) (accessed 2026-05-13)
+- [Application Gateway for Containers FAQ, AKS Automatic support](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) (accessed 2026-05-13)
+- [Quickstart: Deploy AGC ALB Controller AKS add-on (preview), feature flags](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon)
+- [App routing Gateway API (preview), Azure support after November 2026 callout](https://learn.microsoft.com/azure/aks/app-routing-gateway-api)
+- [Ingress NGINX retirement (March 2026)](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/)
+- [Azure Landing Zone guidance for AKS](https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator)
+- [Azure preview supplemental terms](https://azure.microsoft.com/support/legal/preview-supplemental-terms/)
+- [Azure support request process](https://learn.microsoft.com/azure/azure-portal/supportability/how-to-create-azure-support-request)
+- [Azure preview feature registration](https://learn.microsoft.com/azure/azure-resource-manager/management/preview-features)
 - ADR-001: Positioning vs Upstream Tools (private cluster as ALZ Corp default)
+- ADR-004: Toolkit Posture on Preview Features
 - Issue #8: AGC private cluster preview status gate
-- Web search results: AGC private cluster GA expected mid-2026 per engineering blogs, not yet officially confirmed by Microsoft (searched 2026-04-22)


### PR DESCRIPTION
## Wave 3 ADR citation cleanup

Surgical fixes to ADR-001 and ADR-003 grounded in verified MS Learn pages.

### ADR-001
- Replace wrong URL `http-application-routing-migrate` (legacy HTTP application routing addon, not modern App Routing) with the correct App Routing Gateway API caution callout for the Nov 2026 cutoff
- Add Ingress NGINX March 2026 retirement source from kubernetes.dev blog
- Locale-less URLs in References

### ADR-003
- Drop uncited `AGC GA November 2025` specific date claim; cite GA via overview page
- Add verified constraint from AGC FAQ: AKS Automatic supports AGC only via add-on (Helm install unsupported on Automatic). Add-on requires preview feature flags
- Clarify private cluster status: previously cited `private-cluster-support` page is 404; current docs don't explicitly mark private cluster as preview
- Replace embedded 23-region list with canonical `docs/agc-region-matrix.md` link
- Remove unsourced `Web search results` speculation line
- Fix Mar 2026 (community project) vs Nov 2026 (Azure App Routing) conflation

### Sources verified
- https://learn.microsoft.com/azure/application-gateway/for-containers/overview
- https://learn.microsoft.com/azure/application-gateway/for-containers/faq
- https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon
- https://learn.microsoft.com/azure/aks/app-routing-gateway-api
- https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/

Validation: docs only, no IaC or manifest changes.