### PR TITLE
docs: ground README, docs/index, runbook citations in verified MS Learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # aks-automatic-ingress-migration
 
-> **Not an official Microsoft product.** This is a personal community runbook. For Microsoft's supported migration utility, see [Application-Gateway-for-Containers-Migration-Utility](https://github.com/Azure/Application-Gateway-for-Containers-Migration-Utility) and the upstream [`ingress2gateway`](https://github.com/kubernetes-sigs/ingress2gateway) project (1.0 GA).
+> **Not an official Microsoft product.** This is a personal community runbook. For Microsoft's supported migration utility, see [Application-Gateway-for-Containers-Migration-Utility](https://github.com/Azure/Application-Gateway-for-Containers-Migration-Utility) and the upstream [`ingress2gateway`](https://github.com/kubernetes-sigs/ingress2gateway) project ([v1.1.0 latest, April 2026](https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.1.0); [v1.0.0 GA, March 2026](https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.0.0)).
 
-Migration toolkit and runbook for AKS Automatic clusters moving off `ingress-nginx` and the App Routing addon onto **Gateway API + Application Gateway for Containers (AGC)** before the November 2026 critical-only date.
+Migration toolkit and runbook for AKS Automatic clusters moving off `ingress-nginx` and the App Routing addon onto **Gateway API + Application Gateway for Containers (AGC)** before the [November 2026 critical-only date for the App Routing add-on](https://learn.microsoft.com/azure/aks/app-routing-gateway-api).
 
 ## Why this exists
 
 Two timelines collide for AKS Automatic users:
 
-- **March 2026**: community `ingress-nginx` project retires.
-- **November 2026**: Microsoft App Routing addon (managed NGINX) drops to critical-only patches.
+- **March 2026**: community `ingress-nginx` project enters maintenance mode, per [Ingress NGINX retirement](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/).
+- **November 2026**: Microsoft App Routing add-on (managed NGINX) stops receiving Azure support, per the caution callout in [App routing Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api).
 
 The documented migration target is Gateway API with Application Gateway for Containers. The Microsoft docs cover individual primitives. This repo covers the **end-to-end migration** for an ALZ Corp cluster: Terraform/Bicep for AGC, manifest conversion (Ingress → Gateway/HTTPRoute), traffic cutover, rollback, and the operational runbook.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,9 @@ Migration toolkit for AKS Automatic clusters moving from `ingress-nginx` and the
 
 ## Why
 
-- The community `ingress-nginx` project has announced retirement for **March 2026** ([kubernetes/ingress-nginx#10977](https://github.com/kubernetes/ingress-nginx/issues/10977), accessed 2026-04-22).
-- The Microsoft App Routing addon drops to critical-only patches in **November 2026** ([learn.microsoft.com/azure/aks/app-routing](https://learn.microsoft.com/azure/aks/app-routing), accessed 2026-04-22).
-- AKS Automatic ships ingress-nginx by default. Customers who do nothing will be on an unsupported controller.
+- The community `ingress-nginx` project enters maintenance mode in **March 2026**, per [Ingress NGINX retirement](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/).
+- The Microsoft App Routing add-on (managed NGINX) stops receiving Azure support in **November 2026**, per the caution callout in [App routing Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api): "the managed NGINX add-on... will stop receiving Azure support from Azure after November 2026."
+- AKS Automatic ships ingress-nginx by default, per [AKS Automatic overview](https://learn.microsoft.com/azure/aks/intro-aks-automatic). Customers who do nothing will be on an unsupported controller.
 
 ## How to use these docs
 
@@ -14,7 +14,7 @@ Start at the runbook overview. Each phase is independently runnable and ends wit
 
 | Path | What you get |
 |---|---|
-| [Architecture decisions](./adr/) | ADR-001 positioning, ADR-002 Bicep+Terraform parity contract, ADR-003 AGC private cluster preview gate |
+| [Architecture decisions](./adr/) | ADR-001 positioning, ADR-002 Bicep+Terraform parity contract, ADR-003 AGC private cluster preview gate, ADR-004 toolkit posture on preview features |
 | [Migration runbook](./runbook/00-prereq-agc-availability.md) | 10-phase end-to-end runbook from assessment to rollback |
 | [Quickstart sample](../examples/hello-world/README.md) | Smallest reproducible AGC + Gateway API + Workload Identity demo, ALZ Corp defaults |
 | [Migration helper scripts](../scripts/migration/README.md) | PowerShell cmdlets for assessment, conversion, and traffic cutover |

--- a/docs/runbook/00-prereq-agc-availability.md
+++ b/docs/runbook/00-prereq-agc-availability.md
@@ -23,7 +23,7 @@ Before starting Phase 01, confirm:
 - [ ] You have **Network Contributor** on the spoke VNet (needed for AGC subnet delegation).
 - [ ] AKS cluster is on a supported Kubernetes version (see [AKS supported versions](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions), accessed 2026-04-22).
 - [ ] `kubectl`, `helm`, `az` (with `aks-preview` extension), `terraform >= 1.6`, `pwsh >= 7.4` are on PATH.
-- [ ] `ingress2gateway` >= 0.3.0 is on PATH ([upstream releases](https://github.com/kubernetes-sigs/ingress2gateway/releases), accessed 2026-04-22).
+- [ ] `ingress2gateway` >= v1.0.0 ([v1.1.0 latest, April 2026](https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.1.0)) is on PATH.
 - [ ] Read [ADR-003](../adr/ADR-003-agc-private-cluster-preview-gate.md). If your cluster is private and AGC private cluster support is still in preview in your region, you may need a public bastion path for validation.
 
 **Canonical region list:** See the live list at [Application Gateway for Containers overview, Supported regions](https://learn.microsoft.com/azure/application-gateway/for-containers/overview#supported-regions). Snapshot in [`docs/agc-region-matrix.md`](../agc-region-matrix.md).

--- a/docs/runbook/04-translate-manifests.md
+++ b/docs/runbook/04-translate-manifests.md
@@ -8,7 +8,7 @@ Generate `Gateway`, `HTTPRoute`, and supporting policy manifests from the existi
 
 - Phase 01 assessment complete (`assessment.json` on disk).
 - Phase 02 AGC provisioned, controller healthy with identity.
-- `ingress2gateway >= 0.3.0` on PATH.
+- `ingress2gateway >= v1.0.0` ([v1.1.0 latest, April 2026](https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.1.0)) on PATH.
 - A `gateways/` working directory.
 
 ## Steps


### PR DESCRIPTION
## Wave 3 README + runbook citation cleanup

Surgical fixes to bring README, docs/index, and runbook timeline + tool-version claims into compliance with voice profile (every external claim cited inline to MS Learn or upstream GitHub).

### README.md
- ingress2gateway claim: '1.0 GA' bumped to current 'v1.1.0 latest' with v1.0.0 GA reference release URL
- March 2026 + November 2026 timeline claims now have inline citations
- Subtitle Nov 2026 date links to canonical caution callout

### docs/index.md
- March 2026 source upgraded from issue link to kubernetes.dev retirement blog (canonical)
- November 2026 source corrected: was pointing at parent App Routing page (no Nov 2026 specifics), now cites the app-routing-gateway-api page caution callout
- AKS Automatic 'ships ingress-nginx by default' now cites AKS Automatic overview
- ADR-004 added to ADR index entry

### docs/runbook/00-prereq-agc-availability.md and 04-translate-manifests.md
- ingress2gateway >= 0.3.0 (stale, predates v1.0.0 GA) bumped to >= v1.0.0 with v1.1.0 latest reference

### Sources verified
- https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/
- https://learn.microsoft.com/azure/aks/app-routing-gateway-api
- https://learn.microsoft.com/azure/aks/intro-aks-automatic
- https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.1.0
- https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.0.0

Validation: docs only, no IaC or manifest changes.