### PR TITLE
docs: AKS Automatic + AGC accuracy per official FAQ

### DIFF
--- a/docs/preview-features.md
+++ b/docs/preview-features.md
@@ -90,19 +90,24 @@ kubectl get gatewayclass azure-alb-external
 
 ## Migration paths summary
 
-| Starting state | Microsoft's recommended path | Citation |
+| Starting state | Recommended path | Citation |
 |---|---|---|
-| App Routing add-on (NGINX) | App Routing Gateway API impl (preview) | [Enable application routing with Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api) |
-| OSS NGINX (helm-installed) | Either: (a) move to App Routing add-on NGINX through Nov 2026; (b) move to App Routing Gateway API impl; (c) move to AGC | [Enable application routing with Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api) |
-| Adopting AGC fresh | Helm-based ALB Controller (GA) OR AGC AKS add-on (preview) | [Quickstart: Deploy Application Gateway for Containers ALB controller add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) |
+| App Routing add-on (managed NGINX) | App Routing Gateway API impl (preview) | [Enable application routing with Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api) |
+| OSS NGINX (Helm-installed) on standard AKS | Migrate directly to AGC (Helm-installed ALB Controller, GA) or to App Routing Gateway API impl (preview) | [Quickstart: Deploy AGC ALB Controller (Helm)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller) |
+| Adopting AGC on standard AKS | Helm-based ALB Controller (GA) OR AGC AKS add-on (preview) | [Quickstart: Deploy AGC ALB Controller AKS add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) |
+| Adopting AGC on **AKS Automatic** | **AGC AKS add-on (preview) only** — Helm install is unsupported on Automatic | [AGC FAQ, AKS Automatic support](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) |
+
+Note that the AKS Automatic + AGC path requires preview feature flags `ManagedGatewayAPIPreview` and `ApplicationLoadBalancerPreview`. Per ADR-004, this toolkit treats preview features as documented alternatives and does not recommend them as the primary production path.
 
 ## Toolkit posture
 
-This toolkit currently ships Helm-based AGC IaC. The preview AKS add-on is documented for awareness. Whether this toolkit will support that path is tracked in ADR-004-toolkit-posture-on-preview-features.md (Lead is drafting concurrently).
+This toolkit currently ships Helm-based AGC IaC, which is supported only for **standard AKS** (not AKS Automatic) per the FAQ above. Whether to add support for the preview AKS add-on path that AKS Automatic customers require is tracked in [ADR-004](./adr/ADR-004-toolkit-posture-on-preview-features.md).
 
 ## References
 
 - [Enable application routing with Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api)
-- [Quickstart: Deploy Application Gateway for Containers ALB controller add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon)
+- [Quickstart: Deploy AGC ALB Controller AKS add-on (preview)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon)
+- [Quickstart: Deploy AGC ALB Controller via Helm (GA)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller)
 - [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview)
+- [Application Gateway for Containers FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq)
 - [Ingress NGINX maintenance ends March 2026](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/)

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,10 +1,12 @@
 # hello-world sample, ALZ Corp defaults
 
-This sample shows the minimum path for an AKS Automatic workload on Gateway API and Application Gateway for Containers, aligned to ALZ Corp defaults.
+This sample shows the minimum path for a **standard AKS** workload on Gateway API and Application Gateway for Containers, aligned to ALZ Corp defaults.
 
 - Workload Identity is enabled on the application ServiceAccount.
 - The Gateway uses `azure-alb-internal` to avoid a public frontend IP.
 - The cluster model is private API with hub egress via Azure Firewall.
+
+> **AKS Automatic note:** This sample installs the ALB Controller via Helm into `azure-alb-system`. Per the [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) (accessed 2026-05-13): "Helm deployments of the ALB Controller aren't supported with AKS Automatic." AKS Automatic users must instead enable the [AGC ALB Controller AKS add-on (preview)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) and skip step 2 below; see [`docs/preview-features.md`](../../docs/preview-features.md) and [ADR-004](../../docs/adr/ADR-004-toolkit-posture-on-preview-features.md) for the trade-offs.
 
 ## Directory layout
 
@@ -40,8 +42,8 @@ Complete these tasks before you apply the sample manifests:
 2. Install the ALB Controller in `azure-alb-system` and configure Workload Identity federation for `system:serviceaccount:azure-alb-system:alb-controller-sa` to the AGC managed identity client ID.
 3. Confirm the controller is healthy: `kubectl get pods -n azure-alb-system`.
 
-- https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller
-- https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview
+- https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller
+- https://learn.microsoft.com/azure/aks/workload-identity-overview
 
 Update `manifests/serviceaccount.yaml` with the actual managed identity client ID before applying resources.
 
@@ -84,7 +86,8 @@ hello from AGC
 
 ## References
 
-- https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator
-- https://learn.microsoft.com/en-us/azure/aks/private-clusters
-- https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/overview
+- https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator
+- https://learn.microsoft.com/azure/aks/private-clusters
+- https://learn.microsoft.com/azure/application-gateway/for-containers/overview
+- https://learn.microsoft.com/azure/application-gateway/for-containers/faq
 - https://gateway-api.sigs.k8s.io/

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -8,11 +8,13 @@ For production setup, read `docs/runbook/`.
 
 ## Prerequisites
 
-- AKS Automatic cluster (1.30.x or later)
-- Subnet delegated to `Microsoft.ServiceNetworking/trafficControllers`
-- AGC ALB controller installed in the cluster (`azure-alb-system` namespace)
+- AKS cluster on a [supported Kubernetes version](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions)
+- Subnet delegated to `Microsoft.ServiceNetworking/trafficControllers` (per [AGC overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview))
+- AGC ALB controller installed in the cluster (`azure-alb-system` namespace via [Helm install](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller))
 - `kubectl` access to the cluster
 - Terraform or Azure CLI
+
+> **AKS Automatic users:** Per the [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq), the Helm-installed ALB Controller is unsupported on AKS Automatic. Automatic clusters must use the [AGC ALB Controller AKS add-on (preview)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon), which installs the controller into `kube-system` instead. See [`docs/preview-features.md`](../../docs/preview-features.md) for the trade-offs.
 
 ## 1. Provision AGC
 
@@ -75,5 +77,6 @@ Decision #1 defines quickstart scope. Excluded:
 ## References
 
 - Gateway API spec: https://gateway-api.sigs.k8s.io/
-- AGC documentation: https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/
-- AKS Automatic: https://learn.microsoft.com/en-us/azure/aks/intro-aks-automatic
+- AGC documentation: https://learn.microsoft.com/azure/application-gateway/for-containers/
+- AKS Automatic: https://learn.microsoft.com/azure/aks/intro-aks-automatic
+- AGC FAQ (AKS Automatic constraint): https://learn.microsoft.com/azure/application-gateway/for-containers/faq

--- a/presentation/index.html
+++ b/presentation/index.html
@@ -497,10 +497,10 @@ html, body { background: var(--bg); }
       </div>
     </div>
     <p class="citation">
-      <a href="https://github.com/kubernetes/ingress-nginx/issues/10977">kubernetes/ingress-nginx#10977</a>
-      &middot; <a href="https://learn.microsoft.com/azure/aks/app-routing">MS Docs: App Routing addon</a>
+      <a href="https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/">kubernetes.dev: Ingress NGINX retirement (Mar 2026)</a>
+      &middot; <a href="https://learn.microsoft.com/azure/aks/app-routing-gateway-api">MS Docs: App routing Gateway API (Nov 2026 callout)</a>
     </p>
-    <aside class="notes">The community ingress-nginx project announced retirement for March 2026. Microsoft's App Routing addon, which wraps ingress-nginx, will stop receiving feature updates and drop to critical-only patches in November 2026. After that date, no bug fixes, no security patches except critical CVEs. Staying on ingress-nginx past Nov 2026 is operational risk you cannot offset with budget.</aside>
+    <aside class="notes">The community ingress-nginx project enters maintenance mode in March 2026 per the kubernetes.dev retirement blog. Microsoft's App Routing add-on, which wraps managed NGINX, stops receiving Azure support after November 2026 per the caution callout on the App routing Gateway API page. Staying on managed NGINX past November 2026 is operational risk you cannot offset with budget.</aside>
   </section>
 
   <section>
@@ -508,8 +508,8 @@ html, body { background: var(--bg); }
     <div class="cols left-heavy">
       <div class="col">
         <ul>
-          <li>AGC private cluster support is still <span class="preview">Preview</span>. Hard prerequisite for ALZ Corp.</li>
-          <li>ingress2gateway v1.0 GA is the translator. It does not handle every annotation.</li>
+          <li>AKS Automatic + AGC requires the AKS add-on (preview); Helm install is unsupported on Automatic per <a href="https://learn.microsoft.com/azure/application-gateway/for-containers/faq">AGC FAQ</a>.</li>
+          <li>ingress2gateway v1.1.0 (latest, April 2026) is the translator. It does not handle every annotation.</li>
           <li>ALZ Corp topology needs private cluster API, delegated subnets, Workload Identity wiring.</li>
           <li>SRE teams need lead time on the Gateway API mental model and Helm chart layout.</li>
         </ul>
@@ -522,7 +522,7 @@ html, body { background: var(--bg); }
         </div>
       </div>
     </div>
-    <aside class="notes">ALZ Corp environments need hub-spoke topology, Azure Firewall egress, private cluster APIs, and Workload Identity. AGC private cluster support remained in preview as of April 22 2026 with no published GA date. You need time to validate the full stack, run failover scenarios, and train the SRE team on Gateway API.</aside>
+    <aside class="notes">ALZ Corp environments need hub-spoke topology, Azure Firewall egress, private cluster APIs, and Workload Identity. AKS Automatic clusters can only adopt AGC via the AKS add-on, which is in preview as of May 2026 per Microsoft documentation. You need time to validate the full stack, run failover scenarios, and train the SRE team on Gateway API.</aside>
   </section>
 
   <section>
@@ -530,7 +530,7 @@ html, body { background: var(--bg); }
     <div class="grid-2x2">
       <div class="card">
         <h4>Gateway API v1</h4>
-        <p>Kubernetes SIG Network standard, vendor-neutral, GA October 2023.</p>
+        <p>Kubernetes SIG Network standard, vendor-neutral. v1.0.0 tagged 31 October 2023.</p>
       </div>
       <div class="card">
         <h4>Application Gateway for Containers</h4>
@@ -541,15 +541,15 @@ html, body { background: var(--bg); }
         <p>Opinionated cluster profile. Managed addons, Karpenter, deletion locks.</p>
       </div>
       <div class="card">
-        <h4>ingress2gateway v1.0</h4>
-        <p>Official translator from kubernetes-sigs. Run, then review the diff.</p>
+        <h4>ingress2gateway v1.1</h4>
+        <p>Official translator from kubernetes-sigs (v1.0 GA Mar 2026, v1.1 Apr 2026). Run, then review the diff.</p>
       </div>
     </div>
     <p class="citation">
       <a href="https://gateway-api.sigs.k8s.io/">Gateway API spec</a>
       &middot; <a href="https://learn.microsoft.com/azure/application-gateway/for-containers/overview">MS Docs: AGC overview</a>
     </p>
-    <aside class="notes">Gateway API is the SIG Network standard for ingress and service mesh routing, vendor-neutral, GA since October 2023. AGC is Microsoft's managed ingress controller that implements it. AKS Automatic is the opinionated cluster profile, but you can run AGC on standard AKS too. ingress2gateway is the official translator, version 1.0 GA.</aside>
+    <aside class="notes">Gateway API is the SIG Network standard for ingress and service mesh routing, vendor-neutral. v1.0.0 was tagged 31 October 2023 per the GitHub releases. AGC is Microsoft's managed ingress controller that implements it. AKS Automatic is the opinionated cluster profile, but you can run AGC on standard AKS too. ingress2gateway is the official translator: v1.0.0 GA in March 2026, v1.1.0 in April 2026.</aside>
   </section>
 
   <section>
@@ -560,7 +560,7 @@ html, body { background: var(--bg); }
           <li>10-phase runbook tuned for ALZ Corp environments</li>
           <li>Terraform and Bicep modules with enforced output parity</li>
           <li>Helm chart for the AGC controller and Gateway API CRDs</li>
-          <li>Translation guidance built on ingress2gateway v1.0 GA</li>
+          <li>Translation guidance built on ingress2gateway v1.1 (latest, April 2026)</li>
           <li>PowerShell scripts for assessment and dry-run cutover</li>
         </ul>
       </div>
@@ -872,20 +872,20 @@ subject: |
   </section>
 
   <section>
-    <h3>Private cluster AGC is still preview.</h3>
+    <h3>AKS Automatic + AGC requires the preview AKS add-on.</h3>
     <div class="callout">
-      <div class="ribbon">Preview, verified 22 April 2026</div>
-      <p>AGC private cluster support has no published GA date. ALZ Corp requires a private cluster API. This is the gating prerequisite in Phase 00 of the runbook.</p>
+      <div class="ribbon">Preview, verified May 2026</div>
+      <p>Per the <a href="https://learn.microsoft.com/azure/application-gateway/for-containers/faq">AGC FAQ</a>, Helm-installed ALB Controller is unsupported on AKS Automatic. The only supported path is the AGC ALB Controller AKS add-on, which is in preview and requires feature flags <code>ManagedGatewayAPIPreview</code> and <code>ApplicationLoadBalancerPreview</code>.</p>
     </div>
     <ul>
-      <li>If you cannot wait for GA, you accept preview SLA terms</li>
-      <li>Document the risk in your CAB submission</li>
-      <li>Track the Microsoft public roadmap for status changes</li>
+      <li>If you cannot accept preview SLA terms, use standard AKS (not Automatic) with the GA Helm path.</li>
+      <li>Document the preview risk in your CAB submission per ADR-004.</li>
+      <li>Track Azure Updates for GA announcements: <a href="https://azure.microsoft.com/updates/">azure.microsoft.com/updates</a></li>
     </ul>
     <p class="citation">
-      <a href="https://learn.microsoft.com/azure/application-gateway/for-containers/private-cluster-support">MS Docs: AGC private cluster support (preview)</a> &middot; ADR-003
+      <a href="https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon">MS Docs: AGC ALB Controller AKS add-on (preview)</a> &middot; ADR-003 &middot; ADR-004
     </p>
-    <aside class="notes">This is the biggest blocker. ALZ Corp requires private cluster API servers. AGC private cluster support was announced in preview, but as of April 22 2026 it has not reached GA. Microsoft has not published a date. If you cannot wait, accept preview SLA terms (no production support guarantee, breaking changes possible) and document the risk for change advisory.</aside>
+    <aside class="notes">This is the AKS Automatic gating constraint. Per the AGC FAQ, Helm install of the ALB Controller is unsupported on Automatic clusters. The supported path is the AKS managed add-on, which is preview and requires preview feature flags. If you cannot accept preview SLA terms, your alternative is to use standard AKS instead of Automatic, where the GA Helm path is available. Document the preview risk for change advisory.</aside>
   </section>
 
   <section>
@@ -954,22 +954,22 @@ output frontend_id string = frontend.id
         <p class="note">Plan 3 to 6 months end to end for production ALZ Corp. Coexist for at least 2 weeks before cutover, longer if traffic is heavy.</p>
       </div>
     </div>
-    <aside class="notes">Phase 00 is the longest because it depends on Microsoft GA dates. Phases 02 to 04 are network and identity (mostly IaC). Phase 05 is translation and manual annotation review. Phases 07 to 08 are traffic cutover with rollback. Phase 09 is cleanup. 3 to 6 months is realistic for production ALZ Corp.</aside>
+    <aside class="notes">Phase 00 is the longest because it depends on Microsoft GA dates and AKS Automatic preview gates. Phases 02 to 04 are network and identity (mostly IaC). Phase 05 is translation and manual annotation review. Phases 07 to 08 are traffic cutover with rollback. Phase 09 is cleanup. 3 to 6 months is realistic for production ALZ Corp.</aside>
   </section>
 
   <section>
     <h3>Phase 00, do not start without these.</h3>
     <div class="callout">
       <div class="ribbon">Blocker</div>
-      <p>AGC private cluster support reaches GA, or you sign off on the preview risk in writing.</p>
+      <p>For AKS Automatic, accept preview SLA on the AGC AKS add-on (per <a href="https://learn.microsoft.com/azure/application-gateway/for-containers/faq">AGC FAQ</a>) or use standard AKS with the GA Helm path.</p>
     </div>
     <ul>
-      <li>AKS cluster on Kubernetes 1.27 or later</li>
+      <li>AKS cluster on a <a href="https://learn.microsoft.com/azure/aks/supported-kubernetes-versions">supported Kubernetes version</a></li>
       <li>Gateway API CRDs v1 installed, not v1beta1</li>
       <li>Hub-spoke VNets peered, NSGs aligned</li>
       <li>Azure Firewall UDR present on the AKS subnet</li>
     </ul>
-    <aside class="notes">Do not proceed until AGC private cluster support is GA, or you have signed off on the preview risk. Verify the AKS cluster is on Kubernetes 1.27+. Install Gateway API CRDs v1 (not v1beta1). Confirm hub-spoke peering and the firewall UDR. If any are missing, pause and fix before Phase 01.</aside>
+    <aside class="notes">For AKS Automatic, the AGC ALB Controller is only supported via the AKS managed add-on, which is in preview. Decide upfront: accept preview SLA on Automatic, or move to standard AKS where Helm install is GA. Verify the AKS cluster is on a supported Kubernetes version. Install Gateway API CRDs v1 (not v1beta1). Confirm hub-spoke peering and the firewall UDR. If any are missing, pause and fix before Phase 01.</aside>
   </section>
 
   <section>
@@ -1124,9 +1124,9 @@ ingress2gateway translate \
           <div class="label">ALZ Corp migration</div>
         </div>
       </div>
-      <p class="lede" style="margin-top: 36px;">Inventory this week. Plan the network changes. Run ingress2gateway. By the time AGC private cluster goes GA, you want to be ready to apply, not start.</p>
+      <p class="lede" style="margin-top: 36px;">Inventory this week. Plan the network changes. Run ingress2gateway. By the time AGC reaches add-on GA on AKS Automatic, you want to be ready to apply, not start.</p>
     </div>
-    <aside class="notes">As of this deck creation you have 18 months. AGC private cluster support is the gate. Start inventory and planning now. Run the translation tool. Test in staging. Document the risks. Align with security and networking. Don't wait until November 2025 or you will be late.</aside>
+    <aside class="notes">As of this deck creation you have 18 months. The AKS Automatic + AGC add-on is the gate. Start inventory and planning now. Run the translation tool. Test in staging. Document the risks. Align with security and networking. Don't wait until November 2026 or you will be late.</aside>
   </section>
 
 </section>


### PR DESCRIPTION
## Wave 3 AKS Automatic accuracy fix

**Critical finding:** The [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) states explicitly that `Helm deployments of the ALB Controller aren't supported with AKS Automatic.` Multiple toolkit surfaces contradicted this.

### docs/preview-features.md
- Removed wrong claim that App Routing add-on (managed NGINX) is a migration TARGET (it is exactly what's being deprecated)
- Added AKS Automatic row to migration paths table noting the AKS add-on is the only supported path
- Cross-linked GA Helm quickstart and preview add-on quickstart with their respective scopes
- Strengthened toolkit posture section: Helm-based IaC is for standard AKS only

### examples/quickstart/README.md
- Removed unsourced `1.30.x or later` version pin; cite AKS supported Kubernetes versions
- Cite Helm install quickstart for the `azure-alb-system` namespace controller
- Added blockquote redirecting AKS Automatic users to the add-on path
- Locale-less References URLs

### examples/hello-world/README.md
- Reframed scope: this sample is for **standard AKS** (Helm install is unsupported on Automatic)
- Added explicit AKS Automatic blockquote with FAQ citation
- Cross-linked ADR-004 toolkit posture
- Locale-less References URLs

### presentation/index.html
- **Citation fix:** `kubernetes/ingress-nginx#10977` (issue link) -> `kubernetes.dev` Ingress NGINX retirement blog (canonical Mar 2026 source)
- **Citation fix:** parent App Routing page -> `app-routing-gateway-api` caution callout (canonical Nov 2026 source)
- **Frame fix:** Replaced 'AGC private cluster preview' framing (page is now 404) with 'AKS Automatic + AGC add-on preview' framing per current MS docs
- **Version freshness:** ingress2gateway v1.0 GA -> v1.1.0 latest (April 2026); Gateway API GA October 2023 -> 31 October 2023 release date
- **Bug fix:** Closing speaker-note typo `November 2025` -> `November 2026`

### Sources verified (HTTP 200 confirmed)
- https://learn.microsoft.com/azure/application-gateway/for-containers/faq
- https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller
- https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon
- https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller
- https://learn.microsoft.com/azure/aks/app-routing-gateway-api
- https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/

Validation: docs only, no IaC or manifest changes.