### PR TITLE
docs(squad): roll up wave 2 + wave 3 citation grounding decisions

### DIFF
--- a/.squad/agents/atlas/history.md
+++ b/.squad/agents/atlas/history.md
@@ -72,3 +72,17 @@ Activity log for Atlas (Kubernetes manifests, Gateway API translation, Helm).
 - Gateway API v1 CRDs promoted to GA in Gateway API v1.0.0 release (2024-10-30). AKS Automatic 1.30+ recommended for stable support (Kubernetes 1.29 promoted Gateway/HTTPRoute to v1).
 - CI manifest validation uses kubeconform with `--ignore-missing-schemas` (`.github/workflows/validate.yml`). This avoids blocking on AGC-specific CRDs not in kubeconform's built-in schema registry.
 - kubectl --dry-run=client without a live cluster falls back to syntax-only validation (no API server OpenAPI schema fetch).
+
+### 2026-05-13: Wave 2 PR #58 compatibility matrix rewrite
+
+Citation-grounded rewrite of `docs/compatibility-matrix.md`. Single access-date line (no per-row dates), Gateway API v1.0.0 release date verified via [GitHub release tag](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0) (2023-10-31, not 2024-10-30 as previously written), v1.1.0 row added, two preview tool rows added (App Routing Gateway API impl, AGC ALB Controller AKS add-on).
+
+**Lesson:** The first-pass compatibility matrix mis-stated the Gateway API v1.0.0 date by a year (2024 instead of 2023). Always verify release dates against the upstream release tag URL, not memory or another secondary doc. The kubernetes.dev blog post linking to the v1.0.0 release was published October 2023, consistent with the tag date.
+
+### 2026-05-13: Wave 3 corrections to examples and quickstart scoping
+
+PR #65 (executed by @copilot direct) reframed `examples/hello-world` and `examples/quickstart` as targeting standard AKS only, not AKS Automatic. Both READMEs now carry an AKS Automatic blockquote redirecting users to the AGC ALB Controller AKS add-on (preview) path with cross-links to ADR-004 and `docs/preview-features.md`.
+
+Reason: the AGC FAQ states Helm deployments of the ALB Controller are not supported on AKS Automatic. Helm install is the path the toolkit examples use. Therefore the examples cannot run on Automatic without modification.
+
+**Lesson:** Sample scope must match what the install steps actually support. When a constraint exists upstream (FAQ, preview docs), the examples need to either honor it explicitly with a redirect blockquote or implement the alternative path. Half-supporting a platform variant with no warning misleads readers.

--- a/.squad/agents/forge/history.md
+++ b/.squad/agents/forge/history.md
@@ -61,3 +61,11 @@ Per ADR-001, this schema is the orchestration contract consumed by mcp-server-az
 Schema structure defines migration steps with phase enums (prereq, identity, infra, gateway, route, cutover, validate, rollback) and action types (manual, kubectl, helm, terraform, bicep, powershell).
 
 Versioning policy: breaking changes increment version (v1 to v2). Entry point remains at `schema/migration-plan.v1.json` for stable consumers.
+
+### 2026-05-13: Wave 2 PR #59 trafficControllers API version bump
+
+Bumped `Microsoft.ServiceNetworking/trafficControllers` ARM API from `2023-11-01` to `2025-01-01` across 6 IaC files (Terraform azapi resources + Bicep modules). Verified the new API version is GA stable, no breaking schema changes for the toolkit's usage. terraform fmt + validate clean, az bicep build clean.
+
+**Note on contamination:** This PR ended up bundling Atlas (compat matrix), Sage (region matrix + preview-features.md), and Lead (ADR-004 draft) work because all four wave 2 agents ran in parallel sharing the same cwd. Subsequent merges of #58, #60, #61 were no-ops or reconciliation. Wave 3 switched to sequential execution.
+
+**Lesson for IaC API version updates:** When bumping ARM API versions, check both the resource provider GA status (Azure SDK release notes) and any property/schema diffs via `az provider show --resource-types <type>` between versions. For trafficControllers 2023-11-01 → 2025-01-01 the toolkit-used properties (name, location, tags, frontends, associations) were stable.

--- a/.squad/agents/lead/history.md
+++ b/.squad/agents/lead/history.md
@@ -196,3 +196,13 @@ Executed comprehensive gap audit across 11 areas (top-level docs, runbook, ADRs,
 
 Full report written to `.squad/decisions/inbox/lead-gap-audit-2026-05-12.md`.
 
+### 2026-05-13: Wave 2 governance + ADR-004 (Proposed)
+
+Owned PR #61 in citation-grounding wave 2: ADR-004 "Toolkit Posture on Preview Features" (Proposed status), voice profile strengthened with worked ✓/✗ citation hygiene examples, ADR README index entry added.
+
+PR #61 was a no-op on ADR-004 because the parallel-spawned wave 2 agents ran in shared cwd and PR #59 (Forge) ended up bundling Atlas + Sage + Lead drafts. ADR-004 shipped with #59. Reconciliation closed #62 as redundant.
+
+**Open governance question raised in wave 3:** ADR-004 recommends NOT shipping add-on IaC. Wave 3 then verified via the AGC FAQ that AKS Automatic literally cannot use the toolkit's Helm-based IaC. ADR-004 may need re-examination. Drafted as follow-up; awaiting user buy-in on toolkit scope.
+
+**Lesson logged:** Background `task` agents share the cwd; parallel write-mode spawns require `git worktree add` per agent or sequential execution. Wave 3 ran sequentially.
+

--- a/.squad/agents/sage/history.md
+++ b/.squad/agents/sage/history.md
@@ -169,3 +169,14 @@ The corpus was in better shape than expected. Two phrase rewrites, one British s
 - Push branch `chore/wave2-sage-public-sources` and open PR.
 - Decision summary to `.squad/decisions/inbox/sage-wave2-public-sources.md`.
 - Watch for ADR-004 (Lead is drafting) re toolkit posture on preview features. Preview-features.md links to it even though not yet present.
+
+### 2026-05-13: Wave 3 corrections to wave 2 preview-features.md
+
+PR #65 (executed by @copilot direct) fixed two defects in my wave 2 `docs/preview-features.md`:
+
+1. Removed claim that the App Routing add-on (managed NGINX) is a migration target. It is the source workload; users are migrating off it.
+2. Added an AKS Automatic row showing the AGC ALB Controller AKS add-on is the only supported path for AGC on AKS Automatic. Source: [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) — "Helm deployments of the ALB Controller aren't supported with AKS Automatic."
+
+Strengthened toolkit posture wording to make explicit that the Helm-based IaC in this repo targets standard AKS only, not AKS Automatic.
+
+**Lesson:** When documenting migration paths, distinguish source vs target workloads explicitly. The previous table conflated them. Also: when an add-on path is the only supported route on a platform variant, the platform variant deserves its own row, not a footnote.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -229,6 +229,55 @@ After writing the inbox file, Coordinator spawns Scribe (background, haiku) to m
 
 Spawned Sage (docs voice sweep, chore/docs-voice-sweep) and Sage-deck (reveal.js redesign, chore/presentation-redesign) as parallel background agents on 2026-05-12T13:16Z. Both agents completed successfully. PR #49 shipped voice and hygiene sweep across 21 files per `.squad/decisions/inbox/coordinator-spawn-sage-atlas.md`. PR #50 shipped presentation redesign with Charcoal Minimal palette and pptx design principles. PR #51 logged learnings to `.squad/agents/sage/history.md`. All three PRs merged at 13:38-13:40Z. Spawn manifest closed.
 
+### 12. Citation grounding wave 1+2 (Coordinator)
+
+**Date:** 2026-05-13  
+**Author:** martinopedal (via Squad coordinator)  
+**Status:** Completed
+
+Following user directive "all items based on mcp learn findings and other credible documentation sources, with references" + "only use external source material in the repo" + "public material", spawned a 4-agent wave 2 to fix-forward the unsourced wave 1 work.
+
+**Wave 1 PRs (#53-#57)** shipped fast but were not consistently grounded in MS Learn. Audit found: Sage's region matrix invented (PR #55 closed unmerged), Atlas's compatibility matrix missing v1.1.0, Forge's IaC API version stale at 2023-11-01.
+
+**Wave 2 PRs (#58, #59, #60, #61):**
+- #58 (Atlas): Compatibility matrix rewrite. Single access-date line, verified Gateway API v1.0.0 release date (2023-10-31 per GitHub), added v1.1.0 row, added two preview tool rows.
+- #59 (Forge): trafficControllers ARM API bumped 2023-11-01 → 2025-01-01 across 6 IaC files. Verified GA stable, no breaking changes. terraform validate + bicep build clean. (Note: this PR also bundled Atlas + Sage + Lead drafts due to shared-cwd parallel-agent contamination, see entry 13.)
+- #60 (Sage): Region matrix rewrite with verified 23-region MS list inline; created `docs/preview-features.md` covering App Routing Gateway API impl (preview) + AGC ALB Controller AKS add-on (preview); updated README Resources + runbook 00 with preview alternatives.
+- #61 (Lead): ADR-004 (Proposed) "Toolkit Posture on Preview Features"; voice profile strengthened with worked ✓/✗ citation hygiene examples; ADR README index entry.
+
+**Confirmed via MS Learn during wave 2:**
+- AGC supported regions: 23 exact list per https://learn.microsoft.com/azure/application-gateway/for-containers/overview#supported-regions
+- App Routing Gateway API preview feature flag: `AppRoutingIstioGatewayAPIPreview`, GatewayClass `approuting-istio`, requires Managed Gateway API + aks-preview >= 19.0.0b24
+- AGC ALB Controller AKS add-on preview feature flags: `ManagedGatewayAPIPreview` + `ApplicationLoadBalancerPreview`; auto-creates `applicationloadbalancer-<cluster>` MI in MC_ resource group
+- Ingress NGINX retirement: project maintenance ends March 2026 (kubernetes.dev blog); App Routing add-on Azure support ends November 2026 (app-routing-gateway-api caution callout)
+
+**Lessons captured:**
+- Parallel `task` agents share the cwd and contaminate each other's branches when they all modify files before pushing. PR #59 bundled four agents' work. Resolution: wave 3 ran sequentially.
+- Voice profile required worked examples (✓ good inline verifiable / ✗ bad invented) to enforce citation discipline; abstract rules alone did not prevent fabrication.
+- The legacy URL `http-application-routing-migrate` was repeatedly cited for the November 2026 cutoff. It is for the OLD HTTP application routing addon, not the modern App Routing add-on. Correct source is `app-routing-gateway-api` caution callout.
+
+### 13. Citation grounding wave 3 (Coordinator)
+
+**Date:** 2026-05-13  
+**Author:** martinopedal (via Squad coordinator)  
+**Status:** Completed
+
+Wave 3 fixed the remaining citation defects discovered during the wave 2 audit and reconciled the toolkit with a load-bearing fact found while verifying ADR-003: per the [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq), AKS Automatic + AGC requires the AKS managed add-on (preview); Helm-installed ALB Controller is unsupported on AKS Automatic.
+
+**Executed sequentially by @copilot directly** (no sub-agents) to avoid the wave-2 shared-cwd contamination pattern.
+
+**Wave 3 PRs:**
+- #63 ADR cleanup: ADR-001 wrong URL fix (http-application-routing-migrate → app-routing-gateway-api caution callout); ADR-003 reframed (dropped uncited Nov 2025 GA date claim, added AKS Automatic FAQ constraint, removed redundant region list, removed unsourced "Web search results" speculation, fixed Mar 2026 vs Nov 2026 conflation).
+- #64 README + docs/index + runbook citations: bumped ingress2gateway 1.0 GA mentions to v1.1.0 latest with v1.0.0 GA reference; added inline citations to Mar 2026 + Nov 2026 timeline claims; replaced parent app-routing URL with app-routing-gateway-api caution callout; bumped stale `>= 0.3.0` to `>= v1.0.0`.
+- #65 AKS Automatic accuracy: removed wrong claim that App Routing add-on is a migration target; added AKS Automatic row to migration paths table; reframed examples/hello-world as standard AKS only (Helm install unsupported on Automatic per FAQ); added blockquote redirects to add-on path in examples/quickstart and hello-world; presentation deck had 9 fixes including kubernetes.dev citation, app-routing-gateway-api citation, ingress2gateway v1.1.0 version freshness, "AGC private cluster preview" frame replaced with "AKS Automatic + add-on preview" frame, and the closing-slide November 2025 typo corrected to November 2026.
+
+**Open follow-ups:**
+1. Re-examine ADR-004 in light of AKS Automatic constraint: ADR-004 (Proposed) recommends NOT shipping add-on IaC, but AKS Automatic literally cannot use the toolkit's Helm-based IaC. May justify either minimal add-on enablement guidance or a scope decision that the toolkit does not target AKS Automatic until the add-on path reaches GA.
+2. CONTRIBUTING.md line 25 ("Sample apps under `samples/` must run on AKS Automatic with no public IPs") is now inconsistent with wave-3 reframing; future cleanup needed.
+3. `scripts/migration/README.md` references `ingress2gateway@v1.0.0` (GA marker, fine as a minimum); could note v1.1.0 latest for discoverability.
+
+**Validation gates passed (post-merge):** terraform fmt -check -recursive, terraform validate, az bicep build, git status clean.
+
 ## Governance
 
 - All meaningful changes require team consensus


### PR DESCRIPTION
## What

Append entries 12 + 13 to `.squad/decisions.md` and per-agent history entries summarising the citation-grounding waves shipped this session.

## Why

Decisions are the persistent log; the inbox is gitignored local drafting state. Without this rollup, future sessions cannot reconstruct what waves 2 and 3 changed and why.

## Scope

- `.squad/decisions.md`: entries 12 (wave 1+2 across PRs #58, #59, #60, #61) and 13 (wave 3 across PRs #63, #64, #65)
- `.squad/agents/lead/history.md`: ADR-004 (Proposed) + governance lesson on parallel cwd contamination
- `.squad/agents/sage/history.md`: preview-features.md correction (App Routing add-on is source not target; AKS Automatic add-on only)
- `.squad/agents/atlas/history.md`: compat matrix Gateway API v1.0.0 date fix; example scoping correction
- `.squad/agents/forge/history.md`: trafficControllers ARM API bump 2023-11-01 to 2025-01-01; wave 2 contamination note

## Validation

Docs only. No code changed.

Closes the wave 3 work captured in `.squad/decisions/inbox/copilot-wave3-citation-grounding.md` (gitignored).