### PR TITLE
feat(docs): accept ADR-004 and ship AKS Automatic add-on path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ All new customer-facing docs in `docs/` must include the disclaimer from `docs/_
 
 - No em dashes in any markdown or code comments. Use commas, parentheses, or rewrite.
 - Bicep + Terraform parity: every IaC change in one stack must be mirrored in the other before merge.
-- Sample apps under `samples/` must run on AKS Automatic with no public IPs.
+- Sample apps under `examples/` target standard AKS by default and must run with no public IPs (`azure-alb-internal` GatewayClass). AKS Automatic users follow [`docs/aks-automatic-path.md`](docs/aks-automatic-path.md) per ADR-004.
 
 ## Validation gates
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ See [`docs/compatibility-matrix.md`](docs/compatibility-matrix.md). The matrix i
 
 ## Resources
 
+### AKS Automatic users
+
+The standard runbook in this repo provisions AGC via Helm-installed ALB Controller, which is **not supported on AKS Automatic** per the [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq). AKS Automatic users must use the AGC ALB Controller AKS add-on (preview). See [`docs/aks-automatic-path.md`](docs/aks-automatic-path.md) for the verified enablement sequence.
+
 ### Preview features
 
 Microsoft has shipped two preview features that change the migration story. See [`docs/preview-features.md`](docs/preview-features.md).

--- a/docs/adr/ADR-004-toolkit-posture-on-preview-features.md
+++ b/docs/adr/ADR-004-toolkit-posture-on-preview-features.md
@@ -2,9 +2,9 @@
 
 *Not an official Microsoft product. Community migration toolkit. See LICENSE.*
 
-**Status:** Proposed  
+**Status:** Accepted  
 **Date:** 2026-05-13  
-**Deciders:** Lead
+**Deciders:** Lead, Coordinator (per user direction)
 
 ## Context
 
@@ -60,17 +60,25 @@ However, we WILL document preview features as alternatives with clear risk state
 
 ### Question B: Should this toolkit ship IaC for the AGC AKS add-on path?
 
-**No, but document it.** This toolkit will NOT ship IaC modules for the AGC ALB Controller add-on path.
+**No, but document it as a first-class path for AKS Automatic users.** This toolkit will NOT ship IaC modules for the AGC ALB Controller add-on path, but will document the verified `az aks update` enablement sequence in [`docs/aks-automatic-path.md`](../aks-automatic-path.md).
 
-The add-on auto-creates identity in the MC_ resource group. This violates the separation of concerns established in ADR-002 (IaC provisions infrastructure, identity is separate) and in runbook phase 03 (Iris owns identity wiring). Auto-created identities in node resource groups are outside customer control and harder to audit in ALZ Corp environments where RBAC and identity lifecycle are governed processes.
+Rationale for not shipping IaC:
 
-If the add-on reaches GA and becomes the Microsoft-recommended path, we will revisit. Until GA, the Helm-based path is the stable, production-supported option. The add-on is a convenience for customers willing to accept preview risk and MC_ resource group identity management.
+1. The add-on auto-creates identity in the MC_ resource group. This violates the separation of concerns established in ADR-002 (IaC provisions infrastructure, identity is separate) and in runbook phase 03 (Iris owns identity wiring). Auto-created identities in node resource groups are outside customer control and harder to audit in ALZ Corp environments where RBAC and identity lifecycle are governed processes.
+2. The add-on does not produce the same outputs as the Helm path (`agc_identity_client_id`, `agc_subnet_id`, customer-chosen identity name and subnet name). Wrapping it in a Terraform or Bicep module would either break the parity contract (ADR-002) or require a parallel module set with different outputs that downstream consumers must branch on. Both options dilute the toolkit's value.
+3. Preview-as-code is fragile. The add-on is currently behind two preview feature flags (`ManagedGatewayAPIPreview`, `ApplicationLoadBalancerPreview`). If schema or behavior changes at GA, IaC modules become churn that re-implementers must track. Documentation of the canonical `az aks update` command is more durable.
 
-We WILL add a section to `docs/runbook/03-deploy-agc-controller.md` documenting the add-on as an alternative with these warnings:
-1. Preview feature, excluded from SLA.
-2. Auto-creates identity in MC_ resource group, outside typical ALZ Corp governance scope.
-3. No IaC examples provided in this toolkit. Customers must run `az aks update` manually and accept add-on-managed identity and subnet.
-4. Link to [Microsoft's add-on documentation](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon).
+Rationale for documenting it as a first-class AKS Automatic path:
+
+1. Per the [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) (accessed 2026-05-13): "Helm deployments of the ALB Controller aren't supported with AKS Automatic." The add-on is the only supported AGC path on AKS Automatic.
+2. The toolkit's stated audience is AKS Automatic users planning migration before the November 2026 ingress-nginx retirement deadline (per `AGENTS.md`). Without documenting the add-on path, the toolkit cannot serve its declared audience.
+3. Customers who need standard AKS retain the Helm path with full IaC. AKS Automatic customers get a documented, citation-grounded enablement sequence. Both audiences are served without diluting the IaC parity contract.
+
+We have:
+
+1. Created [`docs/aks-automatic-path.md`](../aks-automatic-path.md) with the verified add-on enablement sequence, identity scope notes, validation steps, and rollback. All `az` commands are quoted from the canonical [add-on quickstart](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon).
+2. Marked the add-on path with explicit preview risk warnings linking to [Azure preview supplemental terms](https://azure.microsoft.com/support/legal/preview-supplemental-terms/).
+3. Cross-linked from `README.md`, `docs/index.md`, `docs/preview-features.md`, and the AKS Automatic row of `docs/preview-features.md`'s migration paths table.
 
 ### Question C: Should we document the App Routing Gateway API preview?
 
@@ -103,7 +111,7 @@ This positions the toolkit clearly: we are the AGC path. App Routing Gateway API
 
 ### Neutral
 
-- **No immediate code changes.** This ADR is documentation-only. No IaC changes, no Helm chart changes. Sage updates runbook and creates `docs/alternatives.md`.
+- **No immediate IaC code changes.** This ADR ships one new documentation page (`docs/aks-automatic-path.md`) and updates cross-references. No Terraform, Bicep, or Helm chart changes.
 
 ## Alternatives Considered
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,7 +13,7 @@ This index includes both Accepted ADRs (active decisions) and Proposed ADRs (awa
 | [001](./ADR-001-positioning-vs-upstream-tools.md) | Accepted | 2026-04-22 | Positioning vs upstream tools |
 | [002](./ADR-002-bicep-terraform-parity-contract.md) | Accepted | 2026-04-22 | Bicep and Terraform parity contract |
 | [003](./ADR-003-agc-private-cluster-preview-gate.md) | Accepted | 2026-04-22 | AGC private cluster preview status gate |
-| [004](./ADR-004-toolkit-posture-on-preview-features.md) | Proposed | 2026-05-13 | Toolkit posture on preview features |
+| [004](./ADR-004-toolkit-posture-on-preview-features.md) | Accepted | 2026-05-13 | Toolkit posture on preview features |
 
 ## How to add an ADR
 

--- a/docs/aks-automatic-path.md
+++ b/docs/aks-automatic-path.md
@@ -1,0 +1,169 @@
+# AKS Automatic migration path
+
+*Not an official Microsoft product. Community migration toolkit. See LICENSE.*
+
+---
+
+## Why this page exists
+
+The standard runbook in this repo provisions AGC, installs the ALB Controller via Helm, and wires identity in three separate phases. **That sequence does not work on AKS Automatic.** The [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) (accessed 2026-05-13) states: "Helm deployments of the ALB Controller aren't supported with AKS Automatic." The only supported AGC path on AKS Automatic is the **AGC ALB Controller AKS add-on**, which is currently in preview.
+
+Per [ADR-004](./adr/ADR-004-toolkit-posture-on-preview-features.md), this toolkit treats preview features as documented alternatives and does not ship Terraform or Bicep modules for them. This page documents the verified AKS-add-on path using Microsoft's published commands. Customers who require production support should read the preview risk section before proceeding.
+
+## Preview risk
+
+The two feature flags below are preview. Per [Azure preview supplemental terms](https://azure.microsoft.com/support/legal/preview-supplemental-terms/), "Previews are excluded from the SLAs and limited warranty provided for production services." Production workloads under enterprise compliance need explicit Azure support engagement before adopting this path.
+
+Required feature flags (Microsoft.ContainerService):
+
+- `ManagedGatewayAPIPreview`
+- `ApplicationLoadBalancerPreview`
+
+Citation: [Quickstart: Deploy AGC ALB Controller AKS add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) (accessed 2026-05-13).
+
+## Prerequisites
+
+Verified against the canonical add-on quickstart (accessed 2026-05-13):
+
+- AKS cluster in a [supported AGC region](./agc-region-matrix.md).
+- Azure CNI or Azure CNI Overlay network plugin.
+- OIDC issuer + Workload Identity enabled (default on AKS Automatic; confirm with `az aks show`).
+- Supported AKS Kubernetes version per [supported versions](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions).
+- `az` CLI with `alb` and `aks-preview` extensions installed.
+
+```bash
+az extension add --name alb
+az extension add --name aks-preview
+```
+
+## Steps
+
+### 1. Register feature flags and resource providers
+
+```bash
+az feature register --namespace Microsoft.ContainerService --name ManagedGatewayAPIPreview
+az feature register --namespace Microsoft.ContainerService --name ApplicationLoadBalancerPreview
+
+az provider register --namespace Microsoft.ContainerService
+az provider register --namespace Microsoft.Network
+az provider register --namespace Microsoft.NetworkFunction
+az provider register --namespace Microsoft.ServiceNetworking
+```
+
+Verify registration completes before proceeding:
+
+```bash
+az feature show --namespace Microsoft.ContainerService --name ManagedGatewayAPIPreview --query properties.state
+az feature show --namespace Microsoft.ContainerService --name ApplicationLoadBalancerPreview --query properties.state
+```
+
+Both must report `Registered`. Re-register the resource providers after the features flip to apply the change:
+
+```bash
+az provider register --namespace Microsoft.ContainerService
+```
+
+### 2. Enable the add-on on an existing AKS Automatic cluster
+
+```bash
+AKS_NAME='<your cluster name>'
+RESOURCE_GROUP='<your resource group name>'
+
+az aks update \
+  --name "${AKS_NAME}" \
+  --resource-group "${RESOURCE_GROUP}" \
+  --enable-gateway-api \
+  --enable-application-load-balancer
+```
+
+The add-on auto-creates the following in the AKS node resource group (`MC_<rg>_<cluster>_<region>`), per the add-on quickstart:
+
+- Managed identity `applicationloadbalancer-<cluster-name>` with role assignments **Network Contributor**, **AppGw for Containers Configuration Manager**, and **Reader** on the MC resource group.
+- Federated identity credential `aksfic` for ServiceAccount `kube-system/alb-controller-sa`.
+- Subnet `aks-appgateway` with delegation `Microsoft.ServiceNetworking/TrafficController` (when using AKS-managed VNet).
+
+Per the same source: "It is unsupported to modify the identity or namespace when provisioning integration with the add-on." If you need a customer-controlled identity or subnet name, the add-on path is not appropriate and you should not be on AKS Automatic for this workload.
+
+### 3. Verify ALB Controller pods
+
+```bash
+kubectl get pods -n kube-system | grep alb-controller
+```
+
+Expected: two `alb-controller-*` pods in `Running` state.
+
+### 4. Verify GatewayClass
+
+```bash
+kubectl get gatewayclass azure-alb-external -o yaml
+```
+
+Expected: `status.conditions` contains `type: Accepted, status: "True", message: Valid GatewayClass`.
+
+### 5. Choose a deployment strategy for AGC resources
+
+The add-on installs the ALB Controller. The AGC resource itself (Application Gateway for Containers, Frontend, Association) needs to be created either by the controller or by you:
+
+- **Managed by ALB controller:** controller manages AGC lifecycle from a Kubernetes `ApplicationLoadBalancer` custom resource. Quickstart: [Create AGC managed by ALB controller](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller).
+- **Bring your own (BYO) deployment:** create the AGC resource via Azure portal, CLI, PowerShell, ARM, Terraform, or Bicep, then reference it in Kubernetes config. Quickstart: [Create AGC, BYO deployment](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-byo-deployment).
+
+If you choose BYO on AKS Automatic, the AGC dataplane modules in this repo (`infra/terraform/agc`, `infra/bicep/agc`) can provision the AGC resource. The ALB Controller portion is the add-on.
+
+### 6. Translate ingress manifests and apply
+
+Follow runbook phase [04-translate-manifests.md](./runbook/04-translate-manifests.md) to convert `Ingress` to `Gateway` + `HTTPRoute` using `ingress2gateway`. The translation step is the same regardless of which install path you took.
+
+## Validation
+
+```bash
+# ALB Controller running
+kubectl get pods -n kube-system | grep alb-controller
+
+# GatewayClass accepted
+kubectl get gatewayclass azure-alb-external
+
+# Add-on managed identity present in MC_ resource group
+MC_RG=$(az aks show -g "${RESOURCE_GROUP}" -n "${AKS_NAME}" --query nodeResourceGroup -o tsv)
+az identity list -g "${MC_RG}" --query "[?starts_with(name, 'applicationloadbalancer-')].{name:name, principalId:principalId}" -o table
+
+# Federated credential
+az identity federated-credential list \
+  --identity-name "applicationloadbalancer-${AKS_NAME}" \
+  -g "${MC_RG}" \
+  --query "[?name=='aksfic']" -o table
+```
+
+## Rollback
+
+```bash
+az aks update \
+  --name "${AKS_NAME}" \
+  --resource-group "${RESOURCE_GROUP}" \
+  --disable-gateway-api \
+  --disable-application-load-balancer
+```
+
+This removes the ALB Controller and the add-on managed identity. Any AGC resources created by the controller via `ApplicationLoadBalancer` custom resources are also removed. BYO AGC resources are left in place and must be deleted separately.
+
+Citation: [Quickstart: Deploy AGC ALB Controller AKS add-on, Uninstall section](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon).
+
+## Why this path is not in the standard runbook
+
+The standard runbook assumes:
+
+1. Customer-controlled managed identity in a customer-chosen resource group, wired via Phase 03.
+2. Helm-installed ALB Controller via Phase 02.
+3. IaC-provisioned AGC resources via Terraform or Bicep modules with parity-checked outputs (ADR-002).
+
+The add-on path collapses (1) and (2) into one `az aks update` call, places the identity in `MC_<...>` outside customer governance scope, and breaks the IaC parity contract because the add-on does not produce the same outputs (`agc_identity_client_id`, `agc_subnet_id`, etc.) as the Helm path. ADR-004 documents the rationale for not shipping IaC for the add-on path.
+
+## References
+
+- [AGC FAQ, AKS Automatic support statement](https://learn.microsoft.com/azure/application-gateway/for-containers/faq)
+- [Quickstart: Deploy AGC ALB Controller AKS add-on (preview)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon)
+- [Create AGC, managed by ALB controller](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller)
+- [Create AGC, bring your own deployment](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-byo-deployment)
+- [Azure preview supplemental terms](https://azure.microsoft.com/support/legal/preview-supplemental-terms/)
+- [AKS supported Kubernetes versions](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions)
+- [ADR-004: Toolkit Posture on Preview Features](./adr/ADR-004-toolkit-posture-on-preview-features.md)
+- [Preview features overview](./preview-features.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,8 @@ Start at the runbook overview. Each phase is independently runnable and ends wit
 | Path | What you get |
 |---|---|
 | [Architecture decisions](./adr/) | ADR-001 positioning, ADR-002 Bicep+Terraform parity contract, ADR-003 AGC private cluster preview gate, ADR-004 toolkit posture on preview features |
-| [Migration runbook](./runbook/00-prereq-agc-availability.md) | 10-phase end-to-end runbook from assessment to rollback |
+| [Migration runbook](./runbook/00-prereq-agc-availability.md) | 10-phase end-to-end runbook from assessment to rollback (standard AKS) |
+| [AKS Automatic add-on path](./aks-automatic-path.md) | Add-on (preview) enablement sequence for AKS Automatic users, since Helm is unsupported on Automatic per the [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) |
 | [Quickstart sample](../examples/hello-world/README.md) | Smallest reproducible AGC + Gateway API + Workload Identity demo, ALZ Corp defaults |
 | [Migration helper scripts](../scripts/migration/README.md) | PowerShell cmdlets for assessment, conversion, and traffic cutover |
 | [Presentation deck](../presentation/README.md) | reveal.js HTML deck for internal briefings |

--- a/docs/preview-features.md
+++ b/docs/preview-features.md
@@ -101,7 +101,7 @@ Note that the AKS Automatic + AGC path requires preview feature flags `ManagedGa
 
 ## Toolkit posture
 
-This toolkit currently ships Helm-based AGC IaC, which is supported only for **standard AKS** (not AKS Automatic) per the FAQ above. Whether to add support for the preview AKS add-on path that AKS Automatic customers require is tracked in [ADR-004](./adr/ADR-004-toolkit-posture-on-preview-features.md).
+This toolkit ships Helm-based AGC IaC, which is supported only for **standard AKS** (not AKS Automatic) per the FAQ above. For AKS Automatic users, the toolkit documents the AGC ALB Controller add-on (preview) enablement sequence in [`docs/aks-automatic-path.md`](./aks-automatic-path.md). Per [ADR-004](./adr/ADR-004-toolkit-posture-on-preview-features.md), the toolkit does not ship Terraform or Bicep modules for the add-on path because preview-as-code is fragile and the add-on auto-creates identity outside customer-controlled scope.
 
 ## References
 


### PR DESCRIPTION
## What

Pivots ADR-004 from Proposed to Accepted and ships `docs/aks-automatic-path.md`, a citation-grounded enablement guide for the AGC ALB Controller AKS add-on (preview).

## Why

The toolkit's stated audience is AKS Automatic users (per `AGENTS.md`). The AGC FAQ confirms Helm-installed ALB Controller is unsupported on AKS Automatic. Without the add-on path, the toolkit cannot serve its audience.

User direction (this session): include the AKS Automatic add-on, only use external public source material, do not stop.

## Decision (ADR-004 Accepted)

- **Document the add-on path as first-class for AKS Automatic users.** New page: `docs/aks-automatic-path.md` with the verified `az aks update` sequence, identity scope, validation, and rollback. All commands quoted from the canonical [add-on quickstart](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon).
- **Do NOT ship IaC for the add-on path.** Preview-as-code is fragile. The add-on auto-creates identity in `MC_*` outside customer control, and outputs do not match the Helm path's ADR-002 parity contract.

## Files

- `docs/aks-automatic-path.md` (new)
- `docs/adr/ADR-004-toolkit-posture-on-preview-features.md`: Status Proposed to Accepted; Question B answer rewritten with the new posture and rationale.
- `docs/adr/README.md`: ADR-004 row marked Accepted.
- `README.md`: Resources section now points AKS Automatic users to the new doc.
- `docs/index.md`: navigation table includes new path entry; runbook entry clarified as standard AKS.
- `docs/preview-features.md`: posture paragraph updated to reference new doc.
- `CONTRIBUTING.md`: sample-app rule updated to match wave 3 reframing (examples are standard AKS; AKS Automatic users follow new doc).

## Validation

- `terraform fmt -check -recursive` clean
- `terraform validate` Success across infra/terraform/agc and examples/quickstart/infra
- `az bicep build` clean across all infra/bicep modules
- All cited URLs verified via web fetch on 2026-05-13