### PR TITLE
chore(citations): housekeeping after wave 3 audit

### DIFF
--- a/.squad/agents/sage/charter.md
+++ b/.squad/agents/sage/charter.md
@@ -33,4 +33,4 @@
 
 ## Voice
 
-Cites the date and the URL. "AKS App Routing addon enters critical-only patches Nov 2026 per https://blog.aks.azure.com/2025/11/13/ingress-nginx-update. Migration target is Gateway API + AGC per https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/overview."
+Cites the date and the URL. Example: "ingress-nginx project enters maintenance mode March 2026 per https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/. The App Routing add-on (managed NGINX) stops receiving Azure support after November 2026 per the caution callout in https://learn.microsoft.com/azure/aks/app-routing-gateway-api. Migration target is Gateway API + AGC per https://learn.microsoft.com/azure/application-gateway/for-containers/overview."

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -25,4 +25,4 @@
 - **Project:** aks-automatic-ingress-migration, AKS Automatic migration toolkit from ingress-nginx to AGC + Gateway API
 - **Stack:** Terraform (azurerm + azapi), Bicep, Helm, Gateway API, PowerShell
 - **Created:** 2026-04-22
-- **Deadline anchor:** Nov 2026 App Routing critical-only date
+- **Deadline anchor:** App Routing managed NGINX stops receiving Azure support after November 2026, per the caution callout in [Enable application routing with Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api). Upstream `ingress-nginx` project enters maintenance mode in March 2026, per [Ingress NGINX retirement announcement](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/).

--- a/scripts/migration/README.md
+++ b/scripts/migration/README.md
@@ -11,10 +11,13 @@ PowerShell module for migrating AKS Automatic clusters from ingress-nginx to Gat
 ### Install ingress2gateway
 
 ```shell
+# Pin to GA baseline (v1.0.0, released 2026-03-20):
 go install sigs.k8s.io/ingress2gateway@v1.0.0
+# Or use the latest (v1.1.0 as of 2026-04):
+go install sigs.k8s.io/ingress2gateway@latest
 ```
 
-Or download from https://github.com/kubernetes-sigs/ingress2gateway/releases
+Or download from https://github.com/kubernetes-sigs/ingress2gateway/releases (v1.0.0 GA tag: <https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.0.0>; v1.1.0 latest: <https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.1.0>).
 
 ## Usage
 


### PR DESCRIPTION
## What

Three uncited or stale claims found during the wave 3 audit, fixed:

1. `.squad/agents/sage/charter.md`: removed fictional `blog.aks.azure.com` URL (never existed). Voice example now cites kubernetes.dev (Mar 2026 project end) + app-routing-gateway-api caution callout (Nov 2026 Azure support end).
2. `.squad/team.md`: 'Deadline anchor: Nov 2026' now carries explicit Mar 2026 / Nov 2026 citations.
3. `scripts/migration/README.md`: ingress2gateway snippet shows both v1.0.0 GA pin and v1.1.0 latest with release tag URLs.

## Why

Per user direction (this session): only use external public source material; do not stop. Wave 3 left these three items as low-priority follow-ups; wave 4 PR-B clears them.

## Validation

Docs only. No code or IaC changed.