### PR TITLE
chore(docs): strip locale prefix from MS Learn URLs

### DIFF
--- a/docs/adr/ADR-002-bicep-terraform-parity-contract.md
+++ b/docs/adr/ADR-002-bicep-terraform-parity-contract.md
@@ -122,6 +122,6 @@ We could document parity as a goal but not enforce it in CI. Rejected because un
 - [ADR-001: Positioning vs Upstream Tools](./ADR-001-positioning-vs-upstream-tools.md)
 - [Terraform azurerm provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs)
 - [Terraform azapi provider documentation](https://registry.terraform.io/providers/Azure/azapi/latest/docs)
-- [Bicep resource reference for Application Gateway for Containers](https://learn.microsoft.com/en-us/azure/templates/microsoft.servicenetworking/trafficcontrollers)
-- [Bicep extensibility providers](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-extensibility-kubernetes-provider)
+- [Bicep resource reference for Application Gateway for Containers](https://learn.microsoft.com/azure/templates/microsoft.servicenetworking/trafficcontrollers)
+- [Bicep extensibility providers](https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-extensibility-kubernetes-provider)
 - [Issue #7: Define parity test and CI gate](https://github.com/martinopedal/aks-automatic-ingress-migration/issues/7)

--- a/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
+++ b/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
@@ -8,7 +8,7 @@
 
 ## Context
 
-ADR-001 established ALZ Corp as the default positioning for this repository. ALZ Corp means hub-spoke networks with central Azure Firewall egress, no public IPs on AKS nodes, and private cluster API servers. This is the Microsoft-recommended architecture for enterprise AKS deployments, per [Azure Landing Zone guidance](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator).
+ADR-001 established ALZ Corp as the default positioning for this repository. ALZ Corp means hub-spoke networks with central Azure Firewall egress, no public IPs on AKS nodes, and private cluster API servers. This is the Microsoft-recommended architecture for enterprise AKS deployments, per [Azure Landing Zone guidance](https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator).
 
 Application Gateway for Containers (AGC) is generally available, with feature support including Web Application Firewall (WAF), per [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) (accessed 2026-05-13). However, deployment paths supported on AKS Automatic and on AKS clusters with private API servers warrant explicit verification before adoption.
 
@@ -33,11 +33,11 @@ Concrete deliverables:
 
 2. **Per-region availability matrix:** `docs/agc-region-matrix.md` is the canonical region list for the toolkit, sourced from the AGC overview's [Supported regions](https://learn.microsoft.com/azure/application-gateway/for-containers/overview#supported-regions) section. This ADR does not embed a duplicate region list; readers should consult that file for the verified list.
 
-3. **Quarterly review cadence:** Sage owns a recurring task to check the [Azure Updates page](https://azure.microsoft.com/en-us/updates/) and AGC documentation quarterly. If GA is announced, `docs/runbook/00-prereq-agc-availability.md` and `docs/agc-region-matrix.md` are updated, and the runbook prerequisite check is relaxed or removed.
+3. **Quarterly review cadence:** Sage owns a recurring task to check the [Azure Updates page](https://azure.microsoft.com/updates/) and AGC documentation quarterly. If GA is announced, `docs/runbook/00-prereq-agc-availability.md` and `docs/agc-region-matrix.md` are updated, and the runbook prerequisite check is relaxed or removed.
 
 4. **Escalation path:** The prerequisite document includes links to:
-   - [Azure support request process](https://learn.microsoft.com/en-us/azure/azure-portal/supportability/how-to-create-azure-support-request)
-   - [Azure preview feature registration guidance](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/preview-features)
+   - [Azure support request process](https://learn.microsoft.com/azure/azure-portal/supportability/how-to-create-azure-support-request)
+   - [Azure preview feature registration guidance](https://learn.microsoft.com/azure/azure-resource-manager/management/preview-features)
    - The AKS feedback forum at [feedback.azure.com](https://feedback.azure.com/d365community/forum/8ae9bf04-8326-ec11-b6e6-000d3a4f0789?&c=69637543-1829-ee11-bdf4-000d3a1ab360)
 
 This ADR does not mandate creating the full content of `docs/runbook/00-prereq-agc-availability.md` or `docs/agc-region-matrix.md` immediately. It defines the structure and commits to producing them. Those files will be delivered under separate tracked issues.

--- a/docs/agc-region-matrix.md
+++ b/docs/agc-region-matrix.md
@@ -48,5 +48,5 @@ As of 2026-04-22, AGC support for **private AKS clusters** is in preview in some
 
 ## References
 
-- [Application Gateway for Containers overview](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/overview) — Microsoft Learn
+- [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) — Microsoft Learn
 - [ADR-003: AGC Private Cluster Preview Status Gate](./adr/ADR-003-agc-private-cluster-preview-gate.md)

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -9,9 +9,9 @@ This matrix tracks the validated version set for AKS Automatic migration work in
 
 ## Sources
 
-- AKS supported Kubernetes versions: <https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions>
+- AKS supported Kubernetes versions: <https://learn.microsoft.com/azure/aks/supported-kubernetes-versions>
 - AKS release tracker: <https://releases.aks.azure.com/>
-- AGC ALB Controller release notes: <https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/alb-controller-release-notes>
+- AGC ALB Controller release notes: <https://learn.microsoft.com/azure/application-gateway/for-containers/alb-controller-release-notes>
 - Gateway API releases: <https://github.com/kubernetes-sigs/gateway-api/releases>
 - ingress2gateway releases: <https://github.com/kubernetes-sigs/ingress2gateway/releases>
 - App Routing Gateway API implementation: <https://learn.microsoft.com/azure/aks/app-routing-gateway-api>
@@ -22,9 +22,9 @@ This matrix tracks the validated version set for AKS Automatic migration work in
 
 | Component | Version | Source | Status | Notes |
 |---|---|---|---|---|
-| AKS Automatic | 1.30.x and later | [Supported K8s Versions](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions) | GA | Gateway API v1 promoted to GA in Kubernetes 1.29. AKS Automatic 1.30+ is the recommended baseline for stable Gateway API support. Includes pre-configured managed NGINX. |
+| AKS Automatic | 1.30.x and later | [Supported K8s Versions](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions) | GA | Gateway API v1 promoted to GA in Kubernetes 1.29. AKS Automatic 1.30+ is the recommended baseline for stable Gateway API support. Includes pre-configured managed NGINX. |
 | Gateway API CRDs | v1 (GA) | [v1.0.0 release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0) published 2023-10-31 | GA | Gateway and HTTPRoute resources promoted to v1 API version. Stable for production use. Conformance tests available for implementation validation. |
-| AGC ALB Controller (Helm) | latest stable | [ALB Controller Release Notes](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/alb-controller-release-notes) | GA | Installed via Helm chart. Check release notes for version-specific behavior and CVE patches. |
+| AGC ALB Controller (Helm) | latest stable | [ALB Controller Release Notes](https://learn.microsoft.com/azure/application-gateway/for-containers/alb-controller-release-notes) | GA | Installed via Helm chart. Check release notes for version-specific behavior and CVE patches. |
 | ingress2gateway | v1.1.0 (latest stable) | [v1.0.0](https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.0.0) (2026-03-20), [v1.1.0](https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.1.0) (2026-04-29) | GA | CLI tool for automated Ingress to HTTPRoute translation. v1.1.0 adds Traefik support, app-root, ssl-passthrough, and from-to-www-redirect annotations for ingress-nginx. |
 | App Routing Gateway API impl | preview | [App Routing GA](https://learn.microsoft.com/azure/aks/app-routing-gateway-api) | Preview | AKS-native Gateway API implementation. GatewayClass: `approuting-istio`. Requires `aks-preview` extension >= 19.0.0b24. Istio 1.28+ control plane. |
 | AGC ALB Controller AKS add-on | preview | [Quickstart](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) | Preview | Managed AGC controller deployment. Requires Azure CNI and Workload Identity. Simplifies AGC provisioning without manual Helm installation. |

--- a/docs/runbook/10-threat-model.md
+++ b/docs/runbook/10-threat-model.md
@@ -17,8 +17,8 @@ Default assumptions for this repository:
 
 Reference architecture and AGC platform docs:
 
-- [AKS landing zone accelerator](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator)
-- [Application Gateway for Containers overview](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/overview)
+- [AKS landing zone accelerator](https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/app-platform/aks/landing-zone-accelerator)
+- [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview)
 
 ## Trust boundaries and public surface
 
@@ -44,7 +44,7 @@ Baseline controls:
 
 References:
 
-- [AGC components and data path](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/application-gateway-for-containers-components)
+- [AGC components and data path](https://learn.microsoft.com/azure/application-gateway/for-containers/application-gateway-for-containers-components)
 - [Gateway API HTTP routing model](https://gateway-api.sigs.k8s.io/concepts/api-overview/)
 
 ## NSG and firewall posture
@@ -67,8 +67,8 @@ References:
 
 References:
 
-- [Azure Firewall in hub-spoke networks](https://learn.microsoft.com/en-us/azure/architecture/example-scenario/firewalls/azure-firewall)
-- [AKS egress outbound controls](https://learn.microsoft.com/en-us/azure/aks/limit-egress-traffic)
+- [Azure Firewall in hub-spoke networks](https://learn.microsoft.com/azure/architecture/example-scenario/firewalls/azure-firewall)
+- [AKS egress outbound controls](https://learn.microsoft.com/azure/aks/limit-egress-traffic)
 
 ## mTLS posture
 

--- a/docs/runbook/20-identity-wiring-agc-controller.md
+++ b/docs/runbook/20-identity-wiring-agc-controller.md
@@ -73,7 +73,7 @@ echo "principalId=$PRINCIPAL_ID"
 echo "scope=$AGC_RESOURCE_ID"
 ```
 
-Use the AGC ALB controller setup documentation to select the exact role for your deployment mode: [AGC ALB controller quickstart with Helm](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-helm) and [AGC ALB controller quickstart with AKS add-on](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon).
+Use the AGC ALB controller setup documentation to select the exact role for your deployment mode: [AGC ALB controller quickstart with Helm](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-helm) and [AGC ALB controller quickstart with AKS add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon).
 
 ## 6) Validate token flow and controller health
 
@@ -99,8 +99,8 @@ If validation fails:
 
 ## References
 
-- [Use Microsoft Entra Workload ID with AKS](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)
-- [Deploy and configure Workload Identity on AKS](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster)
-- [Workload identity federation concepts in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation)
-- [AGC ALB controller quickstart with Helm](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-helm)
-- [AGC ALB controller quickstart with AKS add-on](https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon)
+- [Use Microsoft Entra Workload ID with AKS](https://learn.microsoft.com/azure/aks/workload-identity-overview)
+- [Deploy and configure Workload Identity on AKS](https://learn.microsoft.com/azure/aks/workload-identity-deploy-cluster)
+- [Workload identity federation concepts in Microsoft Entra ID](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+- [AGC ALB controller quickstart with Helm](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-helm)
+- [AGC ALB controller quickstart with AKS add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon)

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -49,6 +49,6 @@ kubectl apply --dry-run=server -f manifests/<file>.yaml
 ## References
 
 - Gateway API specification: https://gateway-api.sigs.k8s.io/
-- AGC documentation: https://learn.microsoft.com/en-us/azure/application-gateway/for-containers/
+- AGC documentation: https://learn.microsoft.com/azure/application-gateway/for-containers/
 - ingress2gateway: https://github.com/kubernetes-sigs/ingress2gateway
 - Migration runbook: `docs/runbook/04-translate-manifests.md`


### PR DESCRIPTION
## What

Strip `/en-us/` from all MS Learn URLs across 7 files. Voice profile prefers locale-less URLs because learn.microsoft.com routes to the correct locale via Accept-Language headers, and locale-less URLs survive Microsoft's locale-routing changes.

## Files

- `manifests/README.md` (1 url)
- `docs/compatibility-matrix.md` (4 urls)
- `docs/agc-region-matrix.md` (1 url)
- `docs/adr/ADR-002-bicep-terraform-parity-contract.md` (2 urls)
- `docs/adr/ADR-003-agc-private-cluster-preview-gate.md` (3 urls)
- `docs/runbook/10-threat-model.md` (5 urls)
- `docs/runbook/20-identity-wiring-agc-controller.md` (6 urls)
- Plus 1 azure.microsoft.com/en-us/updates URL in ADR-003

## Validation

URL paths unchanged after the locale segment, no content changes.