### PR TITLE
chore(docs): clear voice profile violations after wave 5 audit

### DIFF
--- a/docs/adr/ADR-004-toolkit-posture-on-preview-features.md
+++ b/docs/adr/ADR-004-toolkit-posture-on-preview-features.md
@@ -128,7 +128,7 @@ Rejected because:
 
 We could document both preview features neutrally without stating a clear recommendation. Let customers decide.
 
-Rejected because this is not opinionated. The toolkit's value is clear guidance. Customers facing the November 2026 deadline need to know what the safest, most production-ready path is. Neutrality is indecision, and indecision slows migration.
+Rejected because this is not opinionated. The toolkit's value is clear guidance. Customers facing the November 2026 deadline need to know what the safest, most stable path is. Neutrality is indecision, and indecision slows migration.
 
 ### Recommend preview for non-prod, Helm for prod
 

--- a/docs/agc-region-matrix.md
+++ b/docs/agc-region-matrix.md
@@ -48,5 +48,5 @@ As of 2026-04-22, AGC support for **private AKS clusters** is in preview in some
 
 ## References
 
-- [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) — Microsoft Learn
+- [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview), Microsoft Learn
 - [ADR-003: AGC Private Cluster Preview Status Gate](./adr/ADR-003-agc-private-cluster-preview-gate.md)

--- a/docs/preview-features.md
+++ b/docs/preview-features.md
@@ -95,7 +95,7 @@ kubectl get gatewayclass azure-alb-external
 | App Routing add-on (managed NGINX) | App Routing Gateway API impl (preview) | [Enable application routing with Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api) |
 | OSS NGINX (Helm-installed) on standard AKS | Migrate directly to AGC (Helm-installed ALB Controller, GA) or to App Routing Gateway API impl (preview) | [Quickstart: Deploy AGC ALB Controller (Helm)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller) |
 | Adopting AGC on standard AKS | Helm-based ALB Controller (GA) OR AGC AKS add-on (preview) | [Quickstart: Deploy AGC ALB Controller AKS add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) |
-| Adopting AGC on **AKS Automatic** | **AGC AKS add-on (preview) only** — Helm install is unsupported on Automatic | [AGC FAQ, AKS Automatic support](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) |
+| Adopting AGC on **AKS Automatic** | **AGC AKS add-on (preview) only** (Helm install is unsupported on Automatic) | [AGC FAQ, AKS Automatic support](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) |
 
 Note that the AKS Automatic + AGC path requires preview feature flags `ManagedGatewayAPIPreview` and `ApplicationLoadBalancerPreview`. Per ADR-004, this toolkit treats preview features as documented alternatives and does not recommend them as the primary production path.
 


### PR DESCRIPTION
Three voice profile violations cleared:

- ADR-004: `production-ready` to `stable`
- agc-region-matrix.md: em dash to comma
- preview-features.md: em dash to parenthetical

After this PR the customer-facing prose has zero em dashes, en dashes, or banned phrases per .squad/skills/voice-profile/SKILL.md.