### PR TITLE
feat(docs): cover Istio add-on ingress, AGC platform requirements, AGIC row

### DIFF
--- a/.squad/agents/sage/history.md
+++ b/.squad/agents/sage/history.md
@@ -180,3 +180,39 @@ PR #65 (executed by @copilot direct) fixed two defects in my wave 2 `docs/previe
 Strengthened toolkit posture wording to make explicit that the Helm-based IaC in this repo targets standard AKS only, not AKS Automatic.
 
 **Lesson:** When documenting migration paths, distinguish source vs target workloads explicitly. The previous table conflated them. Also: when an add-on path is the only supported route on a platform variant, the platform variant deserves its own row, not a footnote.
+
+### 2026-05-13: Wave 7 scenario coverage (Istio add-on ingress, AGC platform requirements)
+
+**Task:** Cover two scenario gaps surfaced by the end-to-end Microsoft Learn audit: Istio service mesh add-on used as an ingress controller (not just sidecar mesh), and explicit AGC platform requirements (no Arc, no Azure Local, no Edge Essentials).
+
+**Context:**
+- Coordinator ran a scenario audit asking "are we covering all scenarios such as Istio without the full functionality?" and "should we extend with a bare metal section too?"
+- Verified via Microsoft Learn MCP fetch (2026-05-13):
+  1. AKS Automatic feature comparison shows Istio add-on ingress gateway is one of three blessed ingress options on Automatic (alongside managed NGINX via App Routing and bring-your-own).
+  2. Istio Gateway API mode (preview, asm-1-26+) is a documented no-AGC, no-migration path per [Configure Istio ingress with Kubernetes Gateway API for AKS (preview)](https://learn.microsoft.com/azure/aks/istio-gateway-api).
+  3. AGC overview and ALB Controller add-on quickstart list only AKS-in-Azure as prerequisites. No mention of Arc, Azure Local, or Edge Essentials support. AGC requires Azure VNets with subnet delegation and AKS-managed primitives.
+
+**Files modified (PR #74):**
+1. `docs/runbook/00-prereq-agc-availability.md`: Split the original "Service Mesh integration (Istio, Linkerd)" bullet into two: one for mesh sidecar coexistence (still out of scope, BackendTLSPolicy cited), one for Istio add-on as ingress controller (documented path, cross-links to preview-features migration paths table). Added new `## AGC platform requirements` section listing non-fits (Arc, Azure Local, Edge Essentials, self-managed K8s on VMs).
+2. `docs/preview-features.md`: Added `## Istio service mesh add-on Gateway API mode (preview)` section after AGC ALB Controller add-on section. Covers what it is, prerequisites (asm-1-26+, Managed Gateway API CRDs), limitations (cannot coexist with App Routing GW API impl, ConfigMap restrictions, TLSRoute SNI passthrough unsupported), MS positioning. Added three new rows to migration paths table (Istio classic → stay on Istio + enable GW API mode; Istio GW API already → no migration needed; AGIC → AGIC-to-AGC migration). Added `## AGC platform support` paragraph after migration paths table.
+3. `docs/runbook/01-assess-current-ingress.md`: Added `### 1.5 Detect non-Ingress traffic management resources` before step 2. Provides detection commands for Istio classic (gateway.networking.istio.io, VirtualService), Gateway API users (gateway.gateway.networking.k8s.io, HTTPRoute), and `gatewayClassName` inspection. Added state-to-path mapping table (gatewayClassName: istio → already on Istio GW API mode, gatewayClassName: approuting-istio → already on App Routing GW API, gatewayClassName: azure-alb-* → already on AGC, VirtualService → Istio classic).
+4. `docs/index.md`: Added one bullet under "Why" listing Istio add-on and AGIC as documented source paths with cross-links to preview-features and runbook 00.
+
+**Learnings:**
+1. **AKS Automatic ingress option triplet.** Per the AKS Automatic feature comparison fetched from MS Learn, ingress on Automatic is "Preconfigured: Managed NGINX using the application routing add-on... Optional: Istio-based service mesh add-on for AKS ingress gateway. Bring your own ingress or gateway." The runbook had only treated ingress-nginx and App Routing (managed NGINX). Istio add-on ingress gateway is a first-class option, not a mesh-only feature.
+2. **Istio Gateway API mode positioning.** The Istio add-on supports both classic Istio APIs (Gateway/VirtualService from gateway.networking.istio.io) and the upstream Kubernetes Gateway API (gateway.networking.k8s.io) on revisions asm-1-26+. Per MS Learn, this is the recommended Gateway API path for Istio add-on users, without migrating to AGC. Cannot coexist with App Routing's Gateway API impl (one GW API controller per cluster).
+3. **AGC platform requirements explicit.** AGC requires AKS in Azure. Azure Arc-enabled Kubernetes, AKS on Azure Local, AKS Edge Essentials, and self-managed Kubernetes on Azure VMs are not supported because AGC subnet delegation and traffic controller provisioning require AKS-in-Azure primitives. Previous docs did not state this explicitly, leading to potential customer confusion.
+4. **Detection commands for non-Ingress users.** An Ingress-only inventory misses Istio classic users (who use gateway.networking.istio.io/v1 Gateway + VirtualService), Istio GW API users (who use gateway.networking.k8s.io/v1 Gateway with gatewayClassName: istio), and existing AGC or App Routing GW API users. Added detection step in Phase 01 with kubectl get commands for all four resource types.
+5. **AGIC row added to migration paths table.** AGIC users have a separate, simpler path per [Migrate from AGIC to AGC](https://learn.microsoft.com/azure/application-gateway/for-containers/migrate-from-agic-to-agc). Previously mentioned only in the "What this runbook does NOT cover" section but not in the consolidated migration paths table. Now both places cross-reference.
+
+**Quality gate applied:**
+- All MS Learn URLs cite section anchors where available (#supported-regions, #limitations-and-considerations).
+- All URLs are locale-less (learn.microsoft.com/azure/..., not learn.microsoft.com/en-us/azure/...).
+- No em dashes, no en dashes, no banned phrases.
+- All citations inline near claims, not parked in References sections.
+- Access date (2026-05-13) included where verification was performed.
+
+**Next steps:**
+- Decision summary to `.squad/decisions/inbox/sage-wave7-scenario-coverage.md`.
+- Watch for future AKS service mesh add-on docs updates (Istio GW API mode may GA in future).
+- Monitor AGC FAQ and overview for Arc/Azure Local/Edge Essentials support announcements (none as of 2026-05-13).

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Migration toolkit for AKS Automatic clusters moving from `ingress-nginx` and the
 - The community `ingress-nginx` project enters maintenance mode in **March 2026**, per [Ingress NGINX retirement](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/).
 - The Microsoft App Routing add-on (managed NGINX) stops receiving Azure support in **November 2026**, per the caution callout in [App routing Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api): "the managed NGINX add-on... will stop receiving Azure support from Azure after November 2026."
 - AKS Automatic ships ingress-nginx by default, per [AKS Automatic overview](https://learn.microsoft.com/azure/aks/intro-aks-automatic). Customers who do nothing will be on an unsupported controller.
+- Other ingress paths: Customers using the Istio service mesh add-on as an ingress controller or AGIC (Application Gateway Ingress Controller) have separate documented paths. See [migration paths table](./preview-features.md#migration-paths-summary) and [Phase 00 prerequisites](./runbook/00-prereq-agc-availability.md#what-this-runbook-does-not-cover) for cross-links.
 
 ## How to use these docs
 

--- a/docs/preview-features.md
+++ b/docs/preview-features.md
@@ -49,6 +49,35 @@ The Application Gateway for Containers ALB Controller is available as an AKS add
 
 Source: [Quickstart: Deploy Application Gateway for Containers ALB controller add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) (accessed 2026-05-12).
 
+## Istio service mesh add-on Gateway API mode (preview)
+
+The Istio service mesh add-on supports the Kubernetes Gateway API (`gateway.networking.k8s.io/v1`) in preview. This provides a Gateway API path for customers already using the Istio add-on for ingress, without migrating to AGC.
+
+Source: [Configure Istio ingress with the Kubernetes Gateway API for AKS (preview)](https://learn.microsoft.com/azure/aks/istio-gateway-api) (accessed 2026-05-13).
+
+### What it is
+
+Istio service mesh add-on with Gateway API CRDs enabled. Uses `gatewayClassName: istio`. Requires Istio add-on revision `asm-1-26` or higher and the AKS Managed Gateway API CRDs add-on enabled on the cluster.
+
+### Prerequisites
+
+- Feature flag: `ManagedGatewayAPIPreview` (Microsoft.ContainerService)
+- Istio service mesh add-on revision `asm-1-26` or higher installed on the cluster per [Deploy Istio-based service mesh add-on for AKS](https://learn.microsoft.com/azure/aks/istio-deploy-addon) (accessed 2026-05-13)
+- Managed Gateway API CRDs enabled per [Enable Managed Gateway API on AKS](https://learn.microsoft.com/azure/aks/managed-gateway-api) (accessed 2026-05-13)
+
+### Limitations
+
+Per the [Limitations and considerations](https://learn.microsoft.com/azure/aks/istio-gateway-api#limitations-and-considerations) section (accessed 2026-05-13):
+
+- Cannot coexist with App Routing Gateway API implementation. You must disable one before enabling the other.
+- ConfigMap customizations for `Gateway` resources must fall within the resource customization allow list. See the [Istio add-on support policy](https://learn.microsoft.com/azure/aks/istio-support-policy#allowed-supported-and-blocked-customizations) (accessed 2026-05-13) for allowed, blocked, and supported features.
+- TLSRoute SNI passthrough (HTTPS ingress to HTTPS services) is unsupported.
+- Egress traffic management with Gateway API via Istio add-on is only supported for the [manual deployment model](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment).
+
+### Microsoft's positioning
+
+This is the recommended Gateway API path for customers already on the Istio service mesh add-on who want Gateway API without migrating off Istio.
+
 ### What it is
 
 Managed installation of the AGC ALB Controller as an AKS add-on. Auto-creates managed identity, federated identity credential, subnet delegation, and role assignments.
@@ -94,10 +123,28 @@ kubectl get gatewayclass azure-alb-external
 |---|---|---|
 | App Routing add-on (managed NGINX) | App Routing Gateway API impl (preview) | [Enable application routing with Gateway API (preview)](https://learn.microsoft.com/azure/aks/app-routing-gateway-api) |
 | OSS NGINX (Helm-installed) on standard AKS | Migrate directly to AGC (Helm-installed ALB Controller, GA) or to App Routing Gateway API impl (preview) | [Quickstart: Deploy AGC ALB Controller (Helm)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller) |
+| Istio service mesh add-on, classic Istio ingress (VirtualService + Gateway) | Stay on Istio, enable Gateway API mode (preview, asm-1-26+) | [Configure Istio ingress with the Kubernetes Gateway API for AKS (preview)](https://learn.microsoft.com/azure/aks/istio-gateway-api) |
+| Istio service mesh add-on already on Gateway API mode | No migration needed (already on Gateway API). Optionally consolidate to AGC if AGC-specific features (WAF, multi-region, Azure integration) are required | n/a (already on target API) |
+| AGIC (Application Gateway Ingress Controller) on standard AKS | Microsoft-published AGIC-to-AGC migration | [Migrate from AGIC to AGC](https://learn.microsoft.com/azure/application-gateway/for-containers/migrate-from-agic-to-agc) |
 | Adopting AGC on standard AKS | Helm-based ALB Controller (GA) OR AGC AKS add-on (preview) | [Quickstart: Deploy AGC ALB Controller AKS add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) |
 | Adopting AGC on **AKS Automatic** | **AGC AKS add-on (preview) only** (Helm install is unsupported on Automatic) | [AGC FAQ, AKS Automatic support](https://learn.microsoft.com/azure/application-gateway/for-containers/faq) |
 
 Note that the AKS Automatic + AGC path requires preview feature flags `ManagedGatewayAPIPreview` and `ApplicationLoadBalancerPreview`. Per ADR-004, this toolkit treats preview features as documented alternatives and does not recommend them as the primary production path.
+
+## AGC platform support
+
+Application Gateway for Containers is supported only on **AKS in Azure**. AGC requires Azure VNets with subnet delegation (`Microsoft.ServiceNetworking/TrafficController`) and AKS-managed identity wiring.
+
+The following platforms are **not supported**:
+
+- Azure Arc-enabled Kubernetes (any non-Azure cluster connected via Arc)
+- AKS on Azure Local (formerly AKS hybrid / Azure Stack HCI)
+- AKS Edge Essentials
+- Self-managed Kubernetes on Azure VMs (without AKS)
+
+**Citations:** [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) (accessed 2026-05-13) and [ALB Controller add-on quickstart prerequisites](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) (accessed 2026-05-13).
+
+For more details, see [`docs/runbook/00-prereq-agc-availability.md#agc-platform-requirements`](./runbook/00-prereq-agc-availability.md#agc-platform-requirements).
 
 ## Toolkit posture
 

--- a/docs/preview-features.md
+++ b/docs/preview-features.md
@@ -49,35 +49,6 @@ The Application Gateway for Containers ALB Controller is available as an AKS add
 
 Source: [Quickstart: Deploy Application Gateway for Containers ALB controller add-on](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) (accessed 2026-05-12).
 
-## Istio service mesh add-on Gateway API mode (preview)
-
-The Istio service mesh add-on supports the Kubernetes Gateway API (`gateway.networking.k8s.io/v1`) in preview. This provides a Gateway API path for customers already using the Istio add-on for ingress, without migrating to AGC.
-
-Source: [Configure Istio ingress with the Kubernetes Gateway API for AKS (preview)](https://learn.microsoft.com/azure/aks/istio-gateway-api) (accessed 2026-05-13).
-
-### What it is
-
-Istio service mesh add-on with Gateway API CRDs enabled. Uses `gatewayClassName: istio`. Requires Istio add-on revision `asm-1-26` or higher and the AKS Managed Gateway API CRDs add-on enabled on the cluster.
-
-### Prerequisites
-
-- Feature flag: `ManagedGatewayAPIPreview` (Microsoft.ContainerService)
-- Istio service mesh add-on revision `asm-1-26` or higher installed on the cluster per [Deploy Istio-based service mesh add-on for AKS](https://learn.microsoft.com/azure/aks/istio-deploy-addon) (accessed 2026-05-13)
-- Managed Gateway API CRDs enabled per [Enable Managed Gateway API on AKS](https://learn.microsoft.com/azure/aks/managed-gateway-api) (accessed 2026-05-13)
-
-### Limitations
-
-Per the [Limitations and considerations](https://learn.microsoft.com/azure/aks/istio-gateway-api#limitations-and-considerations) section (accessed 2026-05-13):
-
-- Cannot coexist with App Routing Gateway API implementation. You must disable one before enabling the other.
-- ConfigMap customizations for `Gateway` resources must fall within the resource customization allow list. See the [Istio add-on support policy](https://learn.microsoft.com/azure/aks/istio-support-policy#allowed-supported-and-blocked-customizations) (accessed 2026-05-13) for allowed, blocked, and supported features.
-- TLSRoute SNI passthrough (HTTPS ingress to HTTPS services) is unsupported.
-- Egress traffic management with Gateway API via Istio add-on is only supported for the [manual deployment model](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment).
-
-### Microsoft's positioning
-
-This is the recommended Gateway API path for customers already on the Istio service mesh add-on who want Gateway API without migrating off Istio.
-
 ### What it is
 
 Managed installation of the AGC ALB Controller as an AKS add-on. Auto-creates managed identity, federated identity credential, subnet delegation, and role assignments.
@@ -116,6 +87,35 @@ kubectl get pods -n kube-system | grep alb-controller
 
 kubectl get gatewayclass azure-alb-external
 ```
+
+## Istio service mesh add-on Gateway API mode (preview)
+
+The Istio service mesh add-on supports the Kubernetes Gateway API (`gateway.networking.k8s.io/v1`) in preview. This provides a Gateway API path for customers already using the Istio add-on for ingress, without migrating to AGC.
+
+Source: [Configure Istio ingress with the Kubernetes Gateway API for AKS (preview)](https://learn.microsoft.com/azure/aks/istio-gateway-api) (accessed 2026-05-13).
+
+### What it is
+
+Istio service mesh add-on with Gateway API CRDs enabled. Uses `gatewayClassName: istio`. Requires Istio add-on revision `asm-1-26` or higher and the AKS Managed Gateway API CRDs add-on enabled on the cluster.
+
+### Prerequisites
+
+- Feature flag: `ManagedGatewayAPIPreview` (Microsoft.ContainerService)
+- Istio service mesh add-on revision `asm-1-26` or higher installed on the cluster per [Deploy Istio-based service mesh add-on for AKS](https://learn.microsoft.com/azure/aks/istio-deploy-addon) (accessed 2026-05-13)
+- Managed Gateway API CRDs enabled per [Enable Managed Gateway API on AKS](https://learn.microsoft.com/azure/aks/managed-gateway-api) (accessed 2026-05-13)
+
+### Limitations
+
+Per the [Limitations and considerations](https://learn.microsoft.com/azure/aks/istio-gateway-api#limitations-and-considerations) section (accessed 2026-05-13):
+
+- Cannot coexist with App Routing Gateway API implementation. You must disable one before enabling the other.
+- ConfigMap customizations for `Gateway` resources must fall within the resource customization allow list. See the [Istio add-on support policy](https://learn.microsoft.com/azure/aks/istio-support-policy#allowed-supported-and-blocked-customizations) (accessed 2026-05-13) for allowed, blocked, and supported features.
+- TLSRoute SNI passthrough (HTTPS ingress to HTTPS services) is unsupported.
+- Egress traffic management with Gateway API via Istio add-on is only supported for the [manual deployment model](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment).
+
+### Microsoft's positioning
+
+This is the recommended Gateway API path for customers already on the Istio service mesh add-on who want Gateway API without migrating off Istio.
 
 ## Migration paths summary
 

--- a/docs/runbook/00-prereq-agc-availability.md
+++ b/docs/runbook/00-prereq-agc-availability.md
@@ -37,8 +37,22 @@ Plan for **3-6 calendar months** end-to-end for an ALZ Corp environment with rea
 ## What this runbook does NOT cover
 
 - Migration off Application Gateway Ingress Controller (AGIC). AGIC users have a separate, simpler path documented at [learn.microsoft.com/azure/application-gateway/for-containers/migrate-from-agic-to-agc](https://learn.microsoft.com/azure/application-gateway/for-containers/migrate-from-agic-to-agc) (accessed 2026-04-22).
-- Service Mesh integration (Istio, Linkerd). AGC supports `BackendTLSPolicy` for upstream mTLS but mesh sidecar coexistence is out of scope.
+- Service mesh sidecar coexistence with AGC. AGC supports `BackendTLSPolicy` for upstream mTLS per the [AGC API specification](https://learn.microsoft.com/azure/application-gateway/for-containers/api-specification-kubernetes#packages) (accessed 2026-05-13), but mesh sidecar injection patterns (Istio, Linkerd) alongside AGC frontends are out of scope.
+- Istio service mesh add-on used as an ingress controller. Customers using the Istio add-on for ingress (not as a full sidecar mesh) have a documented path to adopt the Istio Gateway API mode (preview, asm-1-26+) per [Configure Istio ingress with the Kubernetes Gateway API for AKS (preview)](https://learn.microsoft.com/azure/aks/istio-gateway-api) (accessed 2026-05-13), without migrating to AGC. See the migration paths table in [`docs/preview-features.md`](../preview-features.md#migration-paths-summary).
 - Multi-cluster fleet routing.
+
+## AGC platform requirements
+
+Application Gateway for Containers requires AKS in Azure with Azure VNets. AGC is a PaaS resource (`Microsoft.ServiceNetworking/trafficControllers`) that relies on Azure-managed networking primitives and AKS-specific identity wiring.
+
+The following platforms are **not supported**:
+
+- **Azure Arc-enabled Kubernetes** (any non-Azure cluster connected via Arc). AGC requires Azure VNets with subnet delegation and cannot attach to clusters outside Azure.
+- **AKS on Azure Local** (formerly AKS hybrid / Azure Stack HCI). AGC subnet delegation and traffic controller provisioning require AKS-in-Azure.
+- **AKS Edge Essentials**. AGC is not supported on edge deployment models.
+- **Self-managed Kubernetes on Azure VMs** (without AKS). AGC requires AKS-managed identity federation and control plane integration. Kubernetes clusters deployed manually on Azure VMs do not have these primitives.
+
+**Citations:** [Application Gateway for Containers overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) (accessed 2026-05-13) states "Azure Kubernetes Service (AKS)" as the target platform. The [ALB Controller add-on quickstart prerequisites](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon) (accessed 2026-05-13) lists only AKS-in-Azure prerequisites with no mention of Arc or Azure Local support.
 
 ## Phases at a glance
 

--- a/docs/runbook/01-assess-current-ingress.md
+++ b/docs/runbook/01-assess-current-ingress.md
@@ -24,6 +24,36 @@ Verify count:
 kubectl get ingress -A --no-headers | wc -l
 ```
 
+### 1.5 Detect non-Ingress traffic management resources
+
+An `Ingress`-only inventory misses users of Istio classic APIs (Istio's own Gateway + VirtualService), Istio Gateway API mode, App Routing Gateway API mode, and existing AGC deployments.
+
+Run the following detection commands:
+
+```bash
+# Istio classic ingress users (Istio's own Gateway + VirtualService kinds)
+kubectl get gateway.networking.istio.io -A 2>/dev/null
+kubectl get virtualservice -A 2>/dev/null
+
+# Gateway API users (any controller, including Istio GW API mode and existing AGC)
+kubectl get gateway.gateway.networking.k8s.io -A 2>/dev/null
+kubectl get httproute -A 2>/dev/null
+
+# Identify which controller a Gateway is bound to
+kubectl get gateway.gateway.networking.k8s.io -A -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,CLASS:.spec.gatewayClassName
+```
+
+**Mapping detected state to migration path:**
+
+| Detected state | Recommended path | See |
+|---|---|---|
+| `gatewayClassName: istio` | Already on Istio GW API mode (no migration needed unless consolidating to AGC) | [Preview features, Istio GW API mode](../preview-features.md#istio-service-mesh-add-on-gateway-api-mode-preview) |
+| `gatewayClassName: approuting-istio` | Already on App Routing GW API mode | [Preview features, App Routing GW API](../preview-features.md#app-routing-gateway-api-implementation-preview) |
+| `gatewayClassName: azure-alb-external` or `azure-alb-internal` | Already on AGC (Gateway API) | [Preview features, AGC ALB Controller add-on](../preview-features.md#agc-alb-controller-aks-add-on-preview) |
+| `VirtualService` detected without GW API resources | Istio classic ingress user (path: stay on Istio + enable GW API mode, or migrate to AGC) | [Preview features, migration paths table](../preview-features.md#migration-paths-summary) |
+
+Proceed to the next step only if `Ingress` resources or non-AGC Gateway resources are detected.
+
 ### 2. Run the assessment cmdlet
 
 The repo ships a PowerShell helper that classifies every annotation against the `ingress2gateway` translation matrix and ALZ Corp policy.


### PR DESCRIPTION
Closes the scenario coverage gaps surfaced by the end-to-end Microsoft Learn audit.

## What changed

- **\docs/runbook/00-prereq-agc-availability.md\** distinguishes Istio service mesh add-on as ingress (documented path) from Istio sidecar mesh coexistence (still out of scope). Adds a new section \## AGC platform requirements\ stating AGC is AKS-in-Azure only (no Arc, no Azure Local, no Edge Essentials).
- **\docs/preview-features.md\** adds the Istio service mesh add-on Gateway API mode (preview) section and three new migration paths rows (Istio classic, Istio GW API already, AGIC).
- **\docs/runbook/01-assess-current-ingress.md\** adds detection commands for Istio classic, Istio GW API mode, App Routing GW API, and existing AGC, with a state-to-path mapping.
- **\docs/index.md\** mentions Istio add-on and AGIC as documented source paths.

## Sources verified via Microsoft Learn MCP

- AKS Automatic feature comparison (Istio add-on as one of three blessed ingress options on Automatic)
- Configure Istio ingress with Kubernetes Gateway API for AKS (preview)
- AGC overview prerequisites + ALB Controller add-on quickstart (AKS-in-Azure scope)
- Migrate from AGIC to AGC