### PR TITLE
docs: remove internal squad attribution from customer-facing pages

### DIFF
--- a/docs/adr/ADR-001-positioning-vs-upstream-tools.md
+++ b/docs/adr/ADR-001-positioning-vs-upstream-tools.md
@@ -4,7 +4,7 @@
 
 **Status:** Accepted  
 **Date:** 2026-04-22  
-**Deciders:** Sage, Lead
+**Deciders:** Toolkit maintainers
 
 ## Context
 

--- a/docs/adr/ADR-002-bicep-terraform-parity-contract.md
+++ b/docs/adr/ADR-002-bicep-terraform-parity-contract.md
@@ -4,7 +4,7 @@
 
 **Status:** Accepted  
 **Date:** 2026-04-22  
-**Deciders:** Forge, Lead
+**Deciders:** Toolkit maintainers
 
 ## Context
 
@@ -97,7 +97,7 @@ This workflow runs before any manual review. PRs cannot merge without a passing 
 ### Neutral
 
 - **Not every file requires parity.** Terraform-specific tooling (e.g., `terraform fmt`, `tflint` configs) and Bicep-specific tooling (e.g., `bicepconfig.json`) live in their respective directories without equivalents. Only modules with outputs are subject to parity.
-- **Escape hatch exists.** If a feature is only available in one stack, we document the gap in `.squad/decisions.md` with a "deferred parity" decision and a target date for resolution. This unblocks time-sensitive features while preserving the long-term contract.
+- **Escape hatch exists.** If a feature is only available in one stack, we document the gap as a known parity deferral with a target date for resolution. This unblocks time-sensitive features while preserving the long-term contract.
 
 ## Alternatives considered
 
@@ -111,7 +111,7 @@ We could pick one stack (Terraform or Bicep) as the primary and generate the oth
 
 ### Feature-flag drift with deferred decisions
 
-We keep this as an escape hatch. If a feature is only available in azapi or Bicep extensibility providers, we document the gap in `.squad/decisions.md` with a target resolution date. Example: "AGC custom health probes are azapi-only as of 2026-04-22, Bicep parity deferred to 2026-05-15 pending azurerm provider release." This prevents blocking legitimate features while preserving the parity contract as the default.
+We keep this as an escape hatch. If a feature is only available in azapi or Bicep extensibility providers, we document the gap as a known parity deferral with a target resolution date. Example: "AGC custom health probes are azapi-only as of 2026-04-22, Bicep parity deferred to 2026-05-15 pending azurerm provider release." This prevents blocking legitimate features while preserving the parity contract as the default.
 
 ### No parity enforcement
 

--- a/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
+++ b/docs/adr/ADR-003-agc-private-cluster-preview-gate.md
@@ -4,7 +4,7 @@
 
 **Status:** Accepted  
 **Date:** 2026-04-22  
-**Deciders:** Sage, Sentinel
+**Deciders:** Toolkit maintainers
 
 ## Context
 
@@ -33,7 +33,7 @@ Concrete deliverables:
 
 2. **Per-region availability matrix:** `docs/agc-region-matrix.md` is the canonical region list for the toolkit, sourced from the AGC overview's [Supported regions](https://learn.microsoft.com/azure/application-gateway/for-containers/overview#supported-regions) section. This ADR does not embed a duplicate region list; readers should consult that file for the verified list.
 
-3. **Quarterly review cadence:** Sage owns a recurring task to check the [Azure Updates page](https://azure.microsoft.com/updates/) and AGC documentation quarterly. If GA is announced, `docs/runbook/00-prereq-agc-availability.md` and `docs/agc-region-matrix.md` are updated, and the runbook prerequisite check is relaxed or removed.
+3. **Quarterly review cadence:** Toolkit maintainers run a recurring quarterly task to check the [Azure Updates page](https://azure.microsoft.com/updates/) and AGC documentation. If GA is announced, `docs/runbook/00-prereq-agc-availability.md` and `docs/agc-region-matrix.md` are updated, and the runbook prerequisite check is relaxed or removed.
 
 4. **Escalation path:** The prerequisite document includes links to:
    - [Azure support request process](https://learn.microsoft.com/azure/azure-portal/supportability/how-to-create-azure-support-request)
@@ -54,7 +54,7 @@ This ADR does not mandate creating the full content of `docs/runbook/00-prereq-a
 ### Negative
 
 - **Slows time-to-first-success.** Some customers will hit the prerequisite check and stop, delaying their migration.
-- **Maintenance burden.** Sage must review the matrix quarterly and monitor Azure Updates. This is recurring effort.
+- **Maintenance burden.** Toolkit maintainers review the matrix quarterly and monitor Azure Updates. This is recurring effort.
 - **Complexity for edge cases.** Customers in regions where AGC is not supported at all (outside the 23 listed) need separate guidance. The matrix must account for "not supported" versus "preview" versus "GA."
 
 ### Neutral

--- a/docs/adr/ADR-004-toolkit-posture-on-preview-features.md
+++ b/docs/adr/ADR-004-toolkit-posture-on-preview-features.md
@@ -36,7 +36,7 @@ This preview eliminates the manual Helm installation of the ALB Controller. The 
 
 Enablement: `az aks update --enable-gateway-api --enable-application-load-balancer`.
 
-This collides with our existing IaC scope. Per ADR-002, IaC modules provision AGC infrastructure (Application Gateway for Containers resource, subnet delegation, managed identity, RBAC). Identity management is Iris's domain per runbook phase 03. The add-on auto-creates identity in the node resource group (MC_), which is outside the standard scope for customer-managed identities in ALZ Corp environments.
+This collides with our existing IaC scope. Per ADR-002, IaC modules provision AGC infrastructure (Application Gateway for Containers resource, subnet delegation, managed identity, RBAC). Identity management is covered in runbook phase 03. The add-on auto-creates identity in the node resource group (MC_), which is outside the standard scope for customer-managed identities in ALZ Corp environments.
 
 ### Preview SLA exclusion
 
@@ -44,7 +44,7 @@ Per [Azure preview supplemental terms](https://azure.microsoft.com/support/legal
 
 ### Toolkit's current posture
 
-This toolkit provisions AGC infrastructure via Terraform and Bicep (ADR-002 parity contract), installs ALB Controller via Helm, and separates identity management (runbook phase 03, Iris's domain). This worked when AGC was Helm-only. The two preview features offer alternative paths that reduce customer implementation work but carry preview risk and change identity boundaries.
+This toolkit provisions AGC infrastructure via Terraform and Bicep (ADR-002 parity contract), installs ALB Controller via Helm, and separates identity management (runbook phase 03). This worked when AGC was Helm-only. The two preview features offer alternative paths that reduce customer implementation work but carry preview risk and change identity boundaries.
 
 Toolkit audience: AKS Automatic users planning migration before the November 2026 ingress-nginx retirement deadline. Many run production workloads under enterprise compliance and SLA requirements.
 
@@ -64,7 +64,7 @@ However, we WILL document preview features as alternatives with clear risk state
 
 Rationale for not shipping IaC:
 
-1. The add-on auto-creates identity in the MC_ resource group. This violates the separation of concerns established in ADR-002 (IaC provisions infrastructure, identity is separate) and in runbook phase 03 (Iris owns identity wiring). Auto-created identities in node resource groups are outside customer control and harder to audit in ALZ Corp environments where RBAC and identity lifecycle are governed processes.
+1. The add-on auto-creates identity in the MC_ resource group. This violates the separation of concerns established in ADR-002 (IaC provisions infrastructure, identity is separate) and in runbook phase 03 (identity wiring is a separate step). Auto-created identities in node resource groups are outside customer control and harder to audit in ALZ Corp environments where RBAC and identity lifecycle are governed processes.
 2. The add-on does not produce the same outputs as the Helm path (`agc_identity_client_id`, `agc_subnet_id`, customer-chosen identity name and subnet name). Wrapping it in a Terraform or Bicep module would either break the parity contract (ADR-002) or require a parallel module set with different outputs that downstream consumers must branch on. Both options dilute the toolkit's value.
 3. Preview-as-code is fragile. The add-on is currently behind two preview feature flags (`ManagedGatewayAPIPreview`, `ApplicationLoadBalancerPreview`). If schema or behavior changes at GA, IaC modules become churn that re-implementers must track. Documentation of the canonical `az aks update` command is more durable.
 
@@ -99,7 +99,7 @@ This positions the toolkit clearly: we are the AGC path. App Routing Gateway API
 ### Positive
 
 - **Clarity for production users.** Customers understand that this toolkit prioritizes production-supported paths. Preview features are documented but not recommended.
-- **Maintains IaC scope integrity.** We do not ship IaC that auto-creates identity outside customer-controlled resource groups. ADR-002 parity contract and Iris's identity boundary remain intact.
+- **Maintains IaC scope integrity.** We do not ship IaC that auto-creates identity outside customer-controlled resource groups. ADR-002 parity contract and the identity boundary in runbook phase 03 remain intact.
 - **Reduces future maintenance risk.** If preview features change or are withdrawn, we have no IaC to maintain or deprecate. Documentation updates are simpler than code deprecation.
 - **Positions AGC correctly.** Customers who need AGC-specific features (WAF, private cluster posture, multi-region, Azure integration) have a clear path. Customers who only need Gateway API and are satisfied with App Routing constraints can skip AGC entirely.
 
@@ -122,7 +122,7 @@ We could treat the add-on as the future and ship IaC for it immediately. Create 
 Rejected because:
 1. Preview features are excluded from SLA. We cannot recommend this for production migrations.
 2. Output schema parity (ADR-002) breaks. The add-on auto-creates identity and subnet in MC_ resource group. Outputs will differ from the Helm path (identity name is `applicationloadbalancer-<cluster-name>` instead of customer-chosen, subnet is `aks-appgateway` instead of customer-chosen). This violates the parity contract.
-3. Identity boundary violation. Iris's runbook phase 03 manages identity separately. The add-on collapses infrastructure and identity into one step, breaking the modular runbook structure.
+3. Identity boundary violation. Runbook phase 03 manages identity separately. The add-on collapses infrastructure and identity into one step, breaking the modular runbook structure.
 
 ### Document but stay silent on recommendation
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,4 +59,4 @@ This index includes both Accepted ADRs (active decisions) and Proposed ADRs (awa
 
 ## Decision log
 
-For a history of how decisions are made and approved, see [`.squad/decisions.md`](../../.squad/decisions.md).
+Architectural decisions follow the format defined in [ADR-template.md](ADR-template.md). Each ADR records context, decision, consequences, and is reviewed before merge.

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,6 +1,5 @@
 # Compatibility matrix
 
-**Owner:** Atlas (`squad:atlas`)  
 **Review cadence:** Quarterly  
 **Last reviewed:** 2026-05-12  
 **Access date:** 2026-05-12

--- a/docs/runbook/10-threat-model.md
+++ b/docs/runbook/10-threat-model.md
@@ -1,6 +1,5 @@
 # Threat Model, AGC Migration Path
 
-**Owner:** Sentinel  
 **Last reviewed:** 2026-05-13
 
 ## Scope

--- a/docs/runbook/20-identity-wiring-agc-controller.md
+++ b/docs/runbook/20-identity-wiring-agc-controller.md
@@ -1,7 +1,5 @@
 # Identity wiring for AGC controller (Workload Identity)
 
-Owner: Iris
-
 This runbook wires the AGC ALB controller to a user-assigned managed identity using AKS Workload Identity and federated credentials, avoiding service principal secrets in cluster.
 
 ## Inputs


### PR DESCRIPTION
## Summary

This PR removes internal squad attribution (cast names and .squad/* references) from 8 customer-facing docs/ files. External readers do not need to know about internal agent roles. Squad attribution belongs in .squad/, not in docs/.

## Changes

**Replaced:**
- Cast names (Sage, Sentinel, Iris, Forge, Atlas, Lead) → 'Toolkit maintainers' or runbook phase references
- .squad/* path references → neutral phrasing

**Files:**
- docs/adr/ADR-001..004: Deciders fields, removed Iris/Sage attributions
- docs/adr/README.md: dropped .squad/decisions.md link
- docs/compatibility-matrix.md: dropped Owner line
- docs/runbook/10-threat-model.md: dropped Owner line  
- docs/runbook/20-identity-wiring-agc-controller.md: dropped Owner line

## Verification

Ran verification grep showing zero squad bleed in docs/:
\\\
Get-ChildItem -Path docs -Recurse -File | Select-String -Pattern '\bSage\b|\bSentinel\b|\bIris\b|\bForge\b|\bAtlas\b|\.squad/'
\\\
Result: Zero matches (only false positives in legitimate prose like 'ingress', 'ServiceAccount').

H2 structure verified intact across all 8 files.

## Rationale

Per user feedback: docs/ is positioned as a community toolkit. Internal squad cast names confuse external contributors and customers. .squad/ is the correct home for agent attribution.