### PR TITLE
docs(smoke): clarify the smoke workflow is a maintainer regression check

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,15 @@ Invoke-Pester scripts/migration/tests
 
 ## Live smoke workflow
 
-[`.github/workflows/smoke-test.yml`](.github/workflows/smoke-test.yml) deploys an ephemeral AKS + AGC environment, probes the public Gateway frontend, and tears it down. It runs weekly on schedule (Mondays 03:00 UTC) and supports manual `workflow_dispatch`.
+[`.github/workflows/smoke-test.yml`](.github/workflows/smoke-test.yml) is a maintainer regression check, not a deployment tool for downstream users. It exists so this repo notices when an AKS minor version bump, an ALB Controller chart update, or an AGC behavior change quietly breaks the documented happy path. It runs weekly on schedule (Mondays 03:00 UTC) and on `workflow_dispatch`.
 
-- **What it deploys:** standard AKS cluster, user-assigned managed identity federated to the ALB Controller service account, ALB Controller installed via Helm in managed-by-controller mode, an `ApplicationLoadBalancer` custom resource (which provisions AGC), and a `hashicorp/http-echo` workload behind a Gateway and HTTPRoute. See [`examples/hello-world/smoke/README.md`](examples/hello-world/smoke/README.md) for the full deploy script and pinned versions.
+For your own deployment, do not rely on the workflow. Read [`examples/hello-world/smoke/deploy.sh`](examples/hello-world/smoke/deploy.sh) as canonical executable reference: it has the real role IDs, Helm chart version, AGC managed-mode annotations, and wait conditions in working order. Adapt to your subscription, network posture, and identity model.
+
+- **What it deploys (when secrets are configured):** standard AKS cluster, user-assigned managed identity federated to the ALB Controller service account, ALB Controller installed via Helm in managed-by-controller mode, an `ApplicationLoadBalancer` custom resource (which provisions AGC), and a `hashicorp/http-echo` workload behind a Gateway and HTTPRoute. See [`examples/hello-world/smoke/README.md`](examples/hello-world/smoke/README.md) for the full deploy script and pinned versions.
 - **Authentication:** GitHub OIDC. Requires `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` repository secrets. The preflight job skips the run with a clear `reason` when secrets are missing, so forks no-op gracefully.
 - **Smoke divergences from the ALZ Corp default posture:** the smoke Gateway uses `gatewayClassName: azure-alb-external` (public frontend) so the GitHub-hosted runner can probe it, and uses standard AKS rather than AKS Automatic because the Helm install path for the ALB Controller is unsupported on Automatic per the [AGC FAQ](https://learn.microsoft.com/azure/application-gateway/for-containers/faq). Production usage follows the ALZ posture documented in [`examples/hello-world/`](examples/hello-world/).
-- **Cost and timing:** ~15 to 20 minutes end to end, ~$0.50 to $1 per run in transient resources. The workflow's final step deletes the smoke resource group; `examples/hello-world/smoke/teardown.sh` does best-effort cleanup of the AKS node resource group.
+- **For forkers:** the workflow is harmless if you do nothing. Without `AZURE_*` secrets the preflight skips and no resources are created. If the weekly run is noise in your tabs, disable it under `Settings → Actions → Workflows → smoke-test`.
+- **Cost and timing (only relevant if you wire secrets):** ~15 to 20 minutes end to end, ~$0.50 to $1 per run in transient resources. The workflow's final step deletes the smoke resource group; `examples/hello-world/smoke/teardown.sh` does best-effort cleanup of the AKS node resource group.
 
 ## Security baseline
 

--- a/examples/hello-world/smoke/README.md
+++ b/examples/hello-world/smoke/README.md
@@ -61,6 +61,27 @@ defaults to the weekly schedule (Mondays 03:00 UTC) plus on-demand
 `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` repository
 secrets are absent, so forks no-op.
 
+## Who this is for
+
+The workflow is a maintainer regression check. It exists so the repo notices
+when an AKS minor version bump, an ALB Controller chart update, or an AGC
+behavior change quietly breaks the documented happy path. It is not a
+deployment tool for downstream users.
+
+If you forked or cloned this repo, you have three options:
+
+1. **Do nothing.** Without `AZURE_*` secrets the preflight skips and no
+   resources are created. The workflow is harmless.
+2. **Disable the schedule** if the weekly run is noise in your Actions tab.
+   `Settings → Actions → Workflows → smoke-test → Disable workflow`.
+3. **Run it against your own subscription** by adding the three secrets and
+   firing `workflow_dispatch`. You will pay the ~$0.50 to $1 per run.
+
+For your own AGC deployment, copy `deploy.sh` and adapt to your subscription,
+network posture, and identity model. The script is the canonical executable
+reference for the role IDs, the Helm chart version, the AGC managed-mode
+annotations, and the wait conditions, all in working order.
+
 ## Local invocation
 
 You can run `deploy.sh` against your own subscription for one-off testing.


### PR DESCRIPTION
## Summary

The smoke workflow's framing in the README implied it was a deployment tool downstream users could rely on. It is not. It is a maintainer regression check that exists so this repo notices when an AKS minor version bump, an ALB Controller chart update, or an AGC behavior change quietly breaks the documented happy path. This PR makes that explicit.

## Changes

1. **`README.md` "Live smoke workflow" section reframed.** Leads with audience (maintainer regression check, not a deployment tool), points readers at `deploy.sh` as canonical executable reference, adds a "for forkers: do nothing, the preflight skips" line.

2. **`examples/hello-world/smoke/README.md` adds a "Who this is for" section** spelling out the three forker options: do nothing (preflight skips), disable the schedule, or wire your own secrets and pay the per-run cost.

No code or workflow changes. Documentation only. Builds on #80.

## AI use disclosure

Drafted with assistance from GitHub Copilot CLI (Claude Opus 4.7). Author reviewed. Per `CONTRIBUTING.md`.
