### PR TITLE
chore(ci): route hosted-runner workflows to Pool P1

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   update-required-checks:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - name: Update required status checks for main
         uses: actions/github-script@v9

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/compatibility-matrix-refresh.yml
+++ b/.github/workflows/compatibility-matrix-refresh.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   open-refresh-issue:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - name: Open quarterly refresh issue
         uses: actions/github-script@v7

--- a/.github/workflows/copilot-auto-merge.yml
+++ b/.github/workflows/copilot-auto-merge.yml
@@ -20,7 +20,7 @@ jobs:
       github.event.pull_request.user.login == 'copilot-swe-agent[bot]' ||
       github.event.pull_request.user.login == 'copilot-swe-agent' ||
       github.event.pull_request.user.login == 'Copilot'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - name: Skip if still draft
         if: github.event.pull_request.draft == true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/iac-parity.yml
+++ b/.github/workflows/iac-parity.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   validate-agc-module:
     name: Validate AGC Module Parity
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   preflight:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     outputs:
       can_run: ${{ steps.check.outputs.can_run }}
       reason: ${{ steps.check.outputs.reason }}
@@ -70,7 +70,7 @@ jobs:
   skip:
     needs: preflight
     if: needs.preflight.outputs.can_run != 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - run: |
           echo "Smoke test skipped."
@@ -79,7 +79,7 @@ jobs:
   smoke:
     needs: preflight
     if: needs.preflight.outputs.can_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   terraform:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
@@ -29,7 +29,7 @@ jobs:
           fi
 
   bicep:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install bicep
@@ -41,7 +41,7 @@ jobs:
           fi
 
   manifests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install kubeconform


### PR DESCRIPTION
## Summary

Route this repo's GitHub-hosted ubuntu workflows onto **Pool P1** (personal-scope KEDA-scaled ACA Linux runners). Mechanical change, no workflow logic touched.

```diff
- runs-on: ubuntu-latest
+ runs-on: [self-hosted, personal, linux, x64]
```

## Files changed (9)

- `branch-protection.yml:1` line(s)
- `codeql.yml:1` line(s)
- `compatibility-matrix-refresh.yml:1` line(s)
- `copilot-auto-merge.yml:1` line(s)
- `dependency-review.yml:1` line(s)
- `gitleaks.yml:1` line(s)
- `iac-parity.yml:1` line(s)
- `smoke-test.yml:3` line(s)
- `validate.yml:3` line(s)

Total `runs-on:` lines rewritten: **13**

## Why

Pool P1 deployed via `martinopedal/personal-runners-infra`. Canonical label set per ADR-0033 in `alz-avm-tf-demo/.squad/decisions.md`:

```
[self-hosted, personal, linux, x64]
```

We pay for GitHub-hosted minutes; routing personal repos to P1 reclaims that spend. KEDA scales runners from zero on queued jobs (~30-60s cold start).

## Validation

Next scheduled run of each workflow exercises P1 end-to-end. If a workflow stays queued >5 min, fall back: temporarily revert that file to `ubuntu-latest` and file an issue against `personal-runners-infra`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
