### PR TITLE
fix(ci): revert to ubuntu-latest — personal repos do not need self-hosted runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ${{ fromJSON(vars.RUNS_ON_LINUX_PERSONAL || '["self-hosted","linux","x64","personal"]') }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   review:
-    runs-on: ${{ fromJSON(vars.RUNS_ON_LINUX_PERSONAL || '["self-hosted","linux","x64","personal"]') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   scan:
-    runs-on: ${{ fromJSON(vars.RUNS_ON_LINUX_PERSONAL || '["self-hosted","linux","x64","personal"]') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   terraform:
-    runs-on: ${{ fromJSON(vars.RUNS_ON_LINUX_PERSONAL || '["self-hosted","linux","x64","personal"]') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
@@ -29,7 +29,7 @@ jobs:
           fi
 
   bicep:
-    runs-on: ${{ fromJSON(vars.RUNS_ON_LINUX_PERSONAL || '["self-hosted","linux","x64","personal"]') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install bicep
@@ -41,7 +41,7 @@ jobs:
           fi
 
   manifests:
-    runs-on: ${{ fromJSON(vars.RUNS_ON_LINUX_PERSONAL || '["self-hosted","linux","x64","personal"]') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install kubeconform


### PR DESCRIPTION
## Context

Personal repos are **Pattern A (martinopedal isolated)**. They should use GitHub-hosted runners, not self-hosted.

## Impact

**17 queued runs cancelled:**
- dependency-review - 4 runs
- codeql - 4 runs
- validate (terraform/bicep/manifests jobs) - 5 runs
- gitleaks - 4 runs

## Changes

Changed 4 workflow files:
- .github/workflows/dependency-review.yml
- .github/workflows/codeql.yml
- .github/workflows/validate.yml (3 jobs: terraform, bicep, manifests)
- .github/workflows/gitleaks.yml

All changed from fromJSON(vars.RUNS_ON_LINUX_PERSONAL) to ubuntu-latest

## References

- .squad/decisions/inbox/alex-fleet-clear-stale-queues-2026-05-21.md
- memory-vault wiki/decisions/runner-network-target-topology-2026-05-21.md

---

**DO NOT self-merge.** Left for Martin's review per P0 incident response protocol.